### PR TITLE
Psr\Log\LogLevel constants accepted as $level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Security` in case of vulnerabilities
 
 ## [0.1] - 2024-07-12
-- A PSR-3 compliant logger with adjustable verbosity based on Backyard\BackyardError
+- A PSR-3 compliant logger with adjustable verbosity (based on Backyard\BackyardError)
 
-[Unreleased]: https://github.com/WorkOfStan/seablast-dist/compare/v0.1...HEAD
-[0.1]: https://github.com/WorkOfStan/seablast-dist/releases/tag/v0.1
+[Unreleased]: https://github.com/WorkOfStan/seablast-logger/compare/v0.1...HEAD
+[0.1]: https://github.com/WorkOfStan/seablast-logger/releases/tag/v0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
-## [0.1] - 2024-07-12
-- A PSR-3 compliant logger with adjustable verbosity (based on Backyard\BackyardError)
+## [0.2] - 2024-07-23
+### Added
+- Class configuration is managed by an array where field names are defined as constants to enable IDE hints.
 
-[Unreleased]: https://github.com/WorkOfStan/seablast-logger/compare/v0.1...HEAD
+### Fixed
+- argument `$level` of method `log` accepts also strings defined in Psr\Log\LogLevel as required by [PSR-3](https://www.php-fig.org/psr/psr-3/)
+
+## [0.1] - 2024-07-12
+- A [PSR-3](https://www.php-fig.org/psr/psr-3/) compliant logger with adjustable verbosity (based on Backyard\BackyardError)
+
+[Unreleased]: https://github.com/WorkOfStan/seablast-logger/compare/v0.2...HEAD
+[0.2]: https://github.com/WorkOfStan/seablast-logger/compare/v0.1...v0.2
 [0.1]: https://github.com/WorkOfStan/seablast-logger/releases/tag/v0.1

--- a/README.md
+++ b/README.md
@@ -1,31 +1,33 @@
 # seablast-logger
 A [PSR-3](http://www.php-fig.org/psr/psr-3/) compliant logger with adjustable verbosity.
 
-The logging levels can be tailored to suit different environments.
+The logging level verbosity can be tailored to suit different environments.
 For instance, in a development environment, the logger can be configured to log more detailed information compared to a production environment, all without changing your code.
 Simply adjust the verbosity.
 
 The `logging_level` is the most important setting. These parameters can be configured when instantiating the logger:
 ```php
+use Seablast\Logger\Logger;
 $conf = array(
+    // THESE ARE THE DEFAULT SETTINGS
     // 0 = send message to PHP's system logger; recommended is however 3, i.e. append to the file destination set in the field 'logging_file'
-    'error_log_message_type' => 0,
+    Logger::CONF_ERROR_LOG_MESSAGE_TYPE => 0,
     // if error_log_message_type equals 3, the message is appended to this file destination (path and name)
-    'logging_file' => '',
-    // log up to the level set here, default=5 = debug
-    'logging_level' => 5,
+    Logger::CONF_LOGGING_FILE => '',
+    // verbosity: log up to the level set here, default=5 = debug
+    Logger::CONF_LOGGING_LEVEL => 5,
     // rename or renumber, if needed
-    'logging_level_name' => array(0 => 'unknown', 1 => 'fatal', 'error', 'warning', 'info', 'debug', 'speed'),
+    Logger::CONF_LOGGING_LEVEL_NAME => array(0 => 'unknown', 1 => 'fatal', 'error', 'warning', 'info', 'debug', 'speed'),
     // the logging level to which the page generation speed (i.e. error_number 6) is to be logged
-    'logging_level_page_speed' => 5,
+    Logger::CONF_LOGGING_LEVEL_PAGE_SPEED => 5,
     // false => use logging_file with log extension as destination; true => adds .Y-m.log to the logging file
-    'log_monthly_rotation' => true,
+    Logger::CONF_LOG_MONTHLY_ROTATION => true,
     // prefix message that took longer than profiling step (float) sec from the previous one by SLOWSTEP
-    'log_profiling_step' => false,
+    Logger::CONF_LOG_PROFILING_STEP => false,
     // fatal error may just be written in log, on production, it is however recommended to set an e-mail, where to announce fatal errors
-    'mail_for_admin_enabled' => false,
+    Logger::CONF_MAIL_FOR_ADMIN_ENABLED => false,
 );
-$logger = new Seablast\Logger\Logger($conf);
+$logger = new Logger($conf);
 ```
 See [test.php](test.php) for usage.
 
@@ -47,8 +49,8 @@ And ignores
 Since Nette\Tracy::v2.6.0, i.e. `"php": ">=7.1"` it is possible to use a PSR-3 adapter, allowing for integration of [seablast/logger](https://github.com/WorkOfStan/seablast-logger).
 
 ```php
-$logger = new Seablast\Logger\Logger();
-$tracyLogger = new Tracy\Bridges\Psr\PsrToTracyLoggerAdapter($logger);
+$logger = new \Seablast\Logger\Logger();
+$tracyLogger = new \Tracy\Bridges\Psr\PsrToTracyLoggerAdapter($logger);
 Debugger::setLogger($tracyLogger);
 Debugger::enable();
 ```

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -19,14 +19,14 @@ class Logger extends AbstractLogger implements LoggerInterface
 // phpcs:disable Generic.Files.LineLength
 
     // Define constants for configuration keys
-    const CONF_ERROR_LOG_MESSAGE_TYPE = 'error_log_message_type';
-    const CONF_LOGGING_FILE = 'logging_file';
-    const CONF_LOGGING_LEVEL = 'logging_level';
-    const CONF_LOGGING_LEVEL_NAME = 'logging_level_name';
-    const CONF_LOGGING_LEVEL_PAGE_SPEED = 'logging_level_page_speed';
-    const CONF_LOG_MONTHLY_ROTATION = 'log_monthly_rotation';
-    const CONF_LOG_PROFILING_STEP = 'log_profiling_step';
-    const CONF_MAIL_FOR_ADMIN_ENABLED = 'mail_for_admin_enabled';
+    public const CONF_ERROR_LOG_MESSAGE_TYPE = 'error_log_message_type';
+    public const CONF_LOGGING_FILE = 'logging_file';
+    public const CONF_LOGGING_LEVEL = 'logging_level';
+    public const CONF_LOGGING_LEVEL_NAME = 'logging_level_name';
+    public const CONF_LOGGING_LEVEL_PAGE_SPEED = 'logging_level_page_speed';
+    public const CONF_LOG_MONTHLY_ROTATION = 'log_monthly_rotation';
+    public const CONF_LOG_PROFILING_STEP = 'log_profiling_step';
+    public const CONF_MAIL_FOR_ADMIN_ENABLED = 'mail_for_admin_enabled';
     
     /** @var array<mixed> int,string,bool,array */
     protected $conf = array();
@@ -231,10 +231,10 @@ class Logger extends AbstractLogger implements LoggerInterface
 
     /**
      * Error_log() modified to log necessary debug information by application to its own log.
-     * Logs with an arbitrary level, i.e. may not log debug info on production.
+     * Logs with an arbitrary verbosity level, i.e. may not log debug info on production.
      * Compliant with PSR-3 http://www.php-fig.org/psr/psr-3/
      *
-     * @param mixed int|string $level Error level
+     * @param mixed $level int|string Error level
      * @param string $message Message to be logged
      * @param array<int> $context OPTIONAL To enable error log filtering 'error_number' field expected or the first element element expected containing number of error category
      *
@@ -284,7 +284,7 @@ class Logger extends AbstractLogger implements LoggerInterface
             LogLevel::DEBUG     => 5,
         ];
         if (is_string($level)) {
-            if (array_key_exist($level, $psr2int)) {
+            if (array_key_exists($level, $psr2int)) {
                 $level = $psr2int[$level];
             } else {
                 $this->error('level has unexpected string value ' . $level . ' message: ' . $message);

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -4,6 +4,7 @@ namespace Seablast\Logger;
 
 use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use Seablast\Logger\LoggerTime;
 
 /**
@@ -223,7 +224,7 @@ class Logger extends AbstractLogger implements LoggerInterface
      * Logs with an arbitrary level, i.e. may not log debug info on production.
      * Compliant with PSR-3 http://www.php-fig.org/psr/psr-3/
      *
-     * @param int $level Error level
+     * @param mixed int|string $level Error level
      * @param string $message Message to be logged
      * @param array<int> $context OPTIONAL To enable error log filtering 'error_number' field expected or the first element element expected containing number of error category
      *
@@ -257,6 +258,30 @@ class Logger extends AbstractLogger implements LoggerInterface
         //TODO: přidat proměnnou $line - mělo by být vždy voláno jako basename(__FILE__)."#".__LINE__ , takže bude jasné, ze které řádky source souboru to bylo voláno
         // Ve výsledku do logu zapíše:
         //[Timestamp: d-M-Y H:i:s] [Logging level] [$error_number] [$_SERVER['SCRIPT_FILENAME']] [username@gethostbyaddr($_SERVER['REMOTE_ADDR'])] [sec od startu stránky] $message
+
+        // psr log levels to numbered severity
+        $psr2int = [
+            LogLevel::EMERGENCY => 0,
+            LogLevel::ALERT     => 1,
+            LogLevel::CRITICAL  => 1,
+            LogLevel::ERROR     => 2,
+            LogLevel::WARNING   => 3,
+            LogLevel::NOTICE    => 4,
+            LogLevel::INFO      => 4,
+            LogLevel::DEBUG     => 5,
+        ];
+        if (is_string($level)) {
+            if (array_key_exist($level, $psr2int)) {
+                $level =  $psr2int[$level];
+            } else {
+                error_log('level has unexpected string value ' . $level);
+                $level = 0;
+            }
+        }
+        if (!is_int($level)) {
+            error_log('level has unexpected type ' . gettype($level));
+            $level = 0;
+        }
 
         if (!is_string($message)) {
             error_log("wrong message: Logger->log({$level}," . print_r($message, true) . ")");

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -314,10 +314,10 @@ class Logger extends AbstractLogger implements LoggerInterface
             )
             // or log page_speed everytime error_number equals 6 and
             // logging_level_page_speed has at least the severity of logging_level
-            || (($error_number === 6) && ($this->conf['logging_level_page_speed'] <= $this->conf[self::CONF_LOGGING_LEVEL]))
+            || (($error_number === 6) && ($this->conf[self::CONF_LOGGING_LEVEL_PAGE_SPEED] <= $this->conf[self::CONF_LOGGING_LEVEL]))
         ) {
             $RUNNING_TIME_PREVIOUS = $this->runningTime;
-            if (((($this->runningTime = round($this->time->getmicrotime() - $this->time->getPageTimestamp(), 4)) - $RUNNING_TIME_PREVIOUS) > $this->conf['log_profiling_step']) && $this->conf['log_profiling_step']) {
+            if (((($this->runningTime = round($this->time->getmicrotime() - $this->time->getPageTimestamp(), 4)) - $RUNNING_TIME_PREVIOUS) > $this->conf[self::CONF_LOG_PROFILING_STEP]) && $this->conf[self::CONF_LOG_PROFILING_STEP]) {
                 $message = "SLOWSTEP " . $message; //110812, PROFILING
             }
 
@@ -326,24 +326,25 @@ class Logger extends AbstractLogger implements LoggerInterface
             //    echo((($level <= 2) ? "<b>" : "") . "{$message} [{$this->runningTime}]" . (($level <= 2) ? "</b>" : "") . "<hr/>" . PHP_EOL); //110811, if fatal or error then bold//111119, RUNNING_TIME
             //}
 
-            $message_prefix = "[" . date("d-M-Y H:i:s") . "] [" . $this->conf['logging_level_name'][$level] . "] [" . $error_number . "] [" . $_SERVER['SCRIPT_FILENAME'] . "] ["
+            $message_prefix = "[" . date("d-M-Y H:i:s") . "] [" . $this->conf[self::CONF_LOGGING_LEVEL_NAME][$level] . "] [" . $error_number . "] [" . $_SERVER['SCRIPT_FILENAME'] . "] ["
                 . $this->user . "@"
                 . (isset($_SERVER['REMOTE_ADDR']) ? gethostbyaddr($_SERVER['REMOTE_ADDR']) : '-')//PHPUnit test (CLI) does not set REMOTE_ADDR
                 . "] [" . $this->runningTime . "] ["
                 . (isset($_SERVER["REQUEST_URI"]) ? $_SERVER["REQUEST_URI"] : '-')//PHPUnit test (CLI) does not set REQUEST_URI
                 . "] ";
             //gethostbyaddr($_SERVER['REMOTE_ADDR'])// co udělá s IP, která nelze přeložit? nebylo by lepší logovat přímo IP?
-            if (($this->conf['error_log_message_type'] == 3) && !$this->conf['logging_file']) {// $logging_file not set and it should be
+            if (($this->conf[self::CONF_ERROR_LOG_MESSAGE_TYPE] == 3) && !$this->conf[self::CONF_LOGGING_FILE]) {// $logging_file not set and it should be
                 $result = error_log($message_prefix . "(error: logging_file should be set!) $message"); // so write into the default destination
                 //zaroven by mohlo poslat mail nebo tak neco .. vypis na obrazovku je asi az krajni reseni
             } else {
-                $messageType = ($this->conf['error_log_message_type'] == 0) ? $this->conf['error_log_message_type'] : 3;
-                $result = ($this->conf['log_monthly_rotation']) ? error_log($message_prefix . $message . (($messageType != 0) ? (PHP_EOL) : ('')), $messageType, "{$this->conf['logging_file']}." . date("Y-m") . ".log") //writes into a monthly rotating file
-                    : error_log($message_prefix . $message . PHP_EOL, $messageType, "{$this->conf['logging_file']}.log"); //writes into one file
+                $messageType = ($this->conf[self::CONF_ERROR_LOG_MESSAGE_TYPE] == 0) ? $this->conf[self::CONF_ERROR_LOG_MESSAGE_TYPE] : 3;
+                $result = ($this->conf[self::CONF_LOG_MONTHLY_ROTATION])
+                    ? error_log($message_prefix . $message . (($messageType != 0) ? (PHP_EOL) : ('')), $messageType, "{$this->conf[self::CONF_LOGGING_FILE]}." . date("Y-m") . ".log") //writes into a monthly rotating file
+                    : error_log($message_prefix . $message . PHP_EOL, $messageType, "{$this->conf[self::CONF_LOGGING_FILE]}.log"); //writes into one file
             }
             // mailto admin. 'mail_for_admin_enabled' has to be an email
-            if ($level == 1 && $this->conf['mail_for_admin_enabled']) {
-                error_log($message_prefix . $message . PHP_EOL, 1, $this->conf['mail_for_admin_enabled']);
+            if ($level == 1 && $this->conf[self::CONF_MAIL_FOR_ADMIN_ENABLED]) {
+                error_log($message_prefix . $message . PHP_EOL, 1, $this->conf[self::CONF_MAIL_FOR_ADMIN_ENABLED]);
             }
         }
         if ($result === false) {

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -271,11 +271,11 @@ class Logger extends AbstractLogger implements LoggerInterface
         // Ve výsledku do logu zapíše:
         //[Timestamp: d-M-Y H:i:s] [Logging level] [$error_number] [$_SERVER['SCRIPT_FILENAME']] [username@gethostbyaddr($_SERVER['REMOTE_ADDR'])] [sec od startu stránky] $message
         if (!is_string($message)) {
-            $message = "wrong message type " . gettype($message) . ": Logger->log({$level}," . print_r($message, true) . ")";
+            $message = "wrong message type " . gettype($message) . ": Logger->log(" . print_r($level, true) . "," . print_r($message, true) . ")";
             $this->error($message);
         }
         // psr log levels to numbered severity
-        $psr2int = [
+        $psr2int = array(
             LogLevel::EMERGENCY => 0,
             LogLevel::ALERT     => 1,
             LogLevel::CRITICAL  => 1,
@@ -284,7 +284,7 @@ class Logger extends AbstractLogger implements LoggerInterface
             LogLevel::NOTICE    => 4,
             LogLevel::INFO      => 4,
             LogLevel::DEBUG     => 5,
-        ];
+        );
         if (is_string($level)) {
             if (array_key_exists($level, $psr2int)) {
                 $level = $psr2int[$level];

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -18,6 +18,16 @@ class Logger extends AbstractLogger implements LoggerInterface
 {
 // phpcs:disable Generic.Files.LineLength
 
+    // Define constants for configuration keys
+    const CONF_ERROR_LOG_MESSAGE_TYPE = 'error_log_message_type';
+    const CONF_LOGGING_FILE = 'logging_file';
+    const CONF_LOGGING_LEVEL = 'logging_level';
+    const CONF_LOGGING_LEVEL_NAME = 'logging_level_name';
+    const CONF_LOGGING_LEVEL_PAGE_SPEED = 'logging_level_page_speed';
+    const CONF_LOG_MONTHLY_ROTATION = 'log_monthly_rotation';
+    const CONF_LOG_PROFILING_STEP = 'log_profiling_step';
+    const CONF_MAIL_FOR_ADMIN_ENABLED = 'mail_for_admin_enabled';
+    
     /** @var array<mixed> int,string,bool,array */
     protected $conf = array();
     /** @var int */

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -39,7 +39,6 @@ class Logger extends AbstractLogger implements LoggerInterface
     protected $time;
     /** @var string*/
     private $user = 'unidentified';
-    // phpcs:disable Generic.Files.LineLength
 
     /**
      *
@@ -56,7 +55,7 @@ class Logger extends AbstractLogger implements LoggerInterface
                 self::CONF_ERROR_LOG_MESSAGE_TYPE => 0,
                 // if error_log_message_type equals 3, the message is appended to this file destination (path and name)
                 self::CONF_LOGGING_FILE => '',
-                // log up to the level set here, default=5 = debug
+                // verbosity: log up to the level set here, default=5 = debug
                 self::CONF_LOGGING_LEVEL => 5,
                 // rename or renumber, if needed
                 self::CONF_LOGGING_LEVEL_NAME => array(
@@ -75,7 +74,8 @@ class Logger extends AbstractLogger implements LoggerInterface
                 self::CONF_LOG_MONTHLY_ROTATION => true,
                 // prefix message that took longer than profiling step (float) sec from the previous one by SLOWSTEP
                 self::CONF_LOG_PROFILING_STEP => false,
-                // UNCOMMENT only if needed //'log_standard_output' => false, //true, pokud má zároveň vypisovat na obrazovku; false, pokud má vypisovat jen do logu
+                // UNCOMMENT only if needed //'log_standard_output' => false,
+                // //true, pokud má zároveň vypisovat na obrazovku; false, pokud má vypisovat jen do logu
                 // fatal error may just be written in log,
                 // on production, it is however recommended to set an e-mail, where to announce fatal errors
                 self::CONF_MAIL_FOR_ADMIN_ENABLED => false,
@@ -86,12 +86,12 @@ class Logger extends AbstractLogger implements LoggerInterface
             throw new \Psr\Log\InvalidArgumentException('The logging_level MUST be an integer.');
         }
         $this->overrideLoggingLevel = $this->conf[self::CONF_LOGGING_LEVEL];
-        //@todo do not use $this->conf but set the class properties right here accordingly; and also provide means to set the values otherwise later
-        //240709 set later is probably not necessary
+        //@todo replace $this->conf by the class properties
     }
 
     /**
-     * Class doesn't automatically use any GET parameter to override the set logging level, as it could be used to flood the error log.
+     * Class doesn't automatically use any GET parameter to override the set logging level,
+     * as it could be used to flood the error log.
      * It is however possible to programmatically raise the logging level set in configuration.
      *
      * @param int $newLevel
@@ -231,6 +231,7 @@ class Logger extends AbstractLogger implements LoggerInterface
         $this->log(5, $message, $context);
     }
 
+    // phpcs:disable Generic.Files.LineLength
     /**
      * Error_log() modified to log necessary debug information by application to its own log.
      * Logs with an arbitrary verbosity level, e.g. debug info on production may be omitted.
@@ -353,6 +354,7 @@ class Logger extends AbstractLogger implements LoggerInterface
             throw new ErrorLogFailureException('error_log() failed');
         }
     }
+    // phpcs:enable
     /** Alternative way:
       Logging levels
       Log level   Description                                                                       Set bit
@@ -370,5 +372,4 @@ class Logger extends AbstractLogger implements LoggerInterface
       4         00000100  Warnings and Trace
       7         00000111  Warnings, Debug, Information and Trace
      */
-    // phpcs:enable
 }

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -17,7 +17,7 @@ use Seablast\Logger\LoggerTime;
 class Logger extends AbstractLogger implements LoggerInterface
 {
     // Define constants for configuration keys
-    // phpcs:disable SlevomatCodingStandard.Classes.ClassConstantVisibility.MissingVisibility
+    // phpcs:disable PSR12.Properties.ConstantVisibility.NotFound
     // todo remove phpcs exception when PHP/5 support removed
     const CONF_ERROR_LOG_MESSAGE_TYPE = 'error_log_message_type';
     const CONF_LOGGING_FILE = 'logging_file';

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -12,22 +12,23 @@ use Seablast\Logger\LoggerTime;
  * - add $RUNNING_TIME = $this->getLastRunningTime();
  * - KEEP dieGraciously
  * - only log calls Seablast\Logger\Logger and catches ErrorLogFailureException('error_log() => return false
- * - when adding PHP/8 support, add :void to the inherited methods and remove PHP/5 support
+ * TODO when adding PHP/8 support, add :void to the inherited methods and remove PHP/5 support
  */
 class Logger extends AbstractLogger implements LoggerInterface
 {
-// phpcs:disable Generic.Files.LineLength
-
     // Define constants for configuration keys
-    public const CONF_ERROR_LOG_MESSAGE_TYPE = 'error_log_message_type';
-    public const CONF_LOGGING_FILE = 'logging_file';
-    public const CONF_LOGGING_LEVEL = 'logging_level';
-    public const CONF_LOGGING_LEVEL_NAME = 'logging_level_name';
-    public const CONF_LOGGING_LEVEL_PAGE_SPEED = 'logging_level_page_speed';
-    public const CONF_LOG_MONTHLY_ROTATION = 'log_monthly_rotation';
-    public const CONF_LOG_PROFILING_STEP = 'log_profiling_step';
-    public const CONF_MAIL_FOR_ADMIN_ENABLED = 'mail_for_admin_enabled';
-    
+    // phpcs:disable SlevomatCodingStandard.Classes.ClassConstantVisibility.MissingVisibility
+    // todo remove phpcs exception when PHP/5 support removed
+    const CONF_ERROR_LOG_MESSAGE_TYPE = 'error_log_message_type';
+    const CONF_LOGGING_FILE = 'logging_file';
+    const CONF_LOGGING_LEVEL = 'logging_level';
+    const CONF_LOGGING_LEVEL_NAME = 'logging_level_name';
+    const CONF_LOGGING_LEVEL_PAGE_SPEED = 'logging_level_page_speed';
+    const CONF_LOG_MONTHLY_ROTATION = 'log_monthly_rotation';
+    const CONF_LOG_PROFILING_STEP = 'log_profiling_step';
+    const CONF_MAIL_FOR_ADMIN_ENABLED = 'mail_for_admin_enabled';
+    // phpcs:enable
+
     /** @var array<mixed> int,string,bool,array */
     protected $conf = array();
     /** @var int */
@@ -38,6 +39,7 @@ class Logger extends AbstractLogger implements LoggerInterface
     protected $time;
     /** @var string*/
     private $user = 'unidentified';
+    // phpcs:disable Generic.Files.LineLength
 
     /**
      *
@@ -81,7 +83,7 @@ class Logger extends AbstractLogger implements LoggerInterface
             $conf
         );
         if (!is_int($this->conf[self::CONF_LOGGING_LEVEL])) {
-            throw new \Psr\Log\InvalidArgumentException('The logging_level is not an integer.');
+            throw new \Psr\Log\InvalidArgumentException('The logging_level MUST be an integer.');
         }
         $this->overrideLoggingLevel = $this->conf[self::CONF_LOGGING_LEVEL];
         //@todo do not use $this->conf but set the class properties right here accordingly; and also provide means to set the values otherwise later
@@ -231,7 +233,7 @@ class Logger extends AbstractLogger implements LoggerInterface
 
     /**
      * Error_log() modified to log necessary debug information by application to its own log.
-     * Logs with an arbitrary verbosity level, i.e. may not log debug info on production.
+     * Logs with an arbitrary verbosity level, e.g. debug info on production may be omitted.
      * Compliant with PSR-3 http://www.php-fig.org/psr/psr-3/
      *
      * @param mixed $level int|string Error level

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -268,7 +268,10 @@ class Logger extends AbstractLogger implements LoggerInterface
         //TODO: přidat proměnnou $line - mělo by být vždy voláno jako basename(__FILE__)."#".__LINE__ , takže bude jasné, ze které řádky source souboru to bylo voláno
         // Ve výsledku do logu zapíše:
         //[Timestamp: d-M-Y H:i:s] [Logging level] [$error_number] [$_SERVER['SCRIPT_FILENAME']] [username@gethostbyaddr($_SERVER['REMOTE_ADDR'])] [sec od startu stránky] $message
-
+        if (!is_string($message)) {
+            $message = "wrong message type " . gettype($message) . ": Logger->log({$level}," . print_r($message, true) . ")";
+            $this->error($message);
+        }
         // psr log levels to numbered severity
         $psr2int = [
             LogLevel::EMERGENCY => 0,
@@ -282,19 +285,14 @@ class Logger extends AbstractLogger implements LoggerInterface
         ];
         if (is_string($level)) {
             if (array_key_exist($level, $psr2int)) {
-                $level =  $psr2int[$level];
+                $level = $psr2int[$level];
             } else {
-                error_log('level has unexpected string value ' . $level);
+                $this->error('level has unexpected string value ' . $level . ' message: ' . $message);
                 $level = 0;
             }
-        }
-        if (!is_int($level)) {
-            error_log('level has unexpected type ' . gettype($level));
+        } elseif (!is_int($level)) {
+            $this->error('level has unexpected type ' . gettype($level) . ' message: ' . $message);
             $level = 0;
-        }
-
-        if (!is_string($message)) {
-            error_log("wrong message: Logger->log({$level}," . print_r($message, true) . ")");
         }
 
         // if context array is set then get the value of the 'error_number' field or the first element
@@ -311,8 +309,6 @@ class Logger extends AbstractLogger implements LoggerInterface
                     array(
                         $this->conf[self::CONF_LOGGING_LEVEL],
                         $this->overrideLoggingLevel,
-                        // $this->conf['error_hack_from_get'], //set potentially as GET parameter
-                        //  $ERROR_HACK, //set as variable in the application script
                     )
                 )
             )

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -51,13 +51,13 @@ class Logger extends AbstractLogger implements LoggerInterface
             array( // default values
                 // 0 = send message to PHP's system logger;
                 // recommended is however 3, i.e. append to the file destination set in the field 'logging_file'
-                'error_log_message_type' => 0,
+                self::CONF_ERROR_LOG_MESSAGE_TYPE => 0,
                 // if error_log_message_type equals 3, the message is appended to this file destination (path and name)
-                'logging_file' => '',
+                self::CONF_LOGGING_FILE => '',
                 // log up to the level set here, default=5 = debug
-                'logging_level' => 5,
+                self::CONF_LOGGING_LEVEL => 5,
                 // rename or renumber, if needed
-                'logging_level_name' => array(
+                self::CONF_LOGGING_LEVEL_NAME => array(
                     0 => 'unknown',
                     1 => 'fatal',
                     'error',
@@ -67,23 +67,23 @@ class Logger extends AbstractLogger implements LoggerInterface
                     'speed'
                 ),
                 // the logging level to which the page generation speed (i.e. error_number 6) is to be logged
-                'logging_level_page_speed' => 5,
+                self::CONF_LOGGING_LEVEL_PAGE_SPEED => 5,
                 // false => use logging_file with log extension as destination
                 // true => adds .Y-m.log to the logging file
-                'log_monthly_rotation' => true,
+                self::CONF_LOG_MONTHLY_ROTATION => true,
                 // prefix message that took longer than profiling step (float) sec from the previous one by SLOWSTEP
-                'log_profiling_step' => false,
+                self::CONF_LOG_PROFILING_STEP => false,
                 // UNCOMMENT only if needed //'log_standard_output' => false, //true, pokud má zároveň vypisovat na obrazovku; false, pokud má vypisovat jen do logu
                 // fatal error may just be written in log,
                 // on production, it is however recommended to set an e-mail, where to announce fatal errors
-                'mail_for_admin_enabled' => false,
+                self::CONF_MAIL_FOR_ADMIN_ENABLED => false,
             ),
             $conf
         );
-        if (!is_int($this->conf['logging_level'])) {
+        if (!is_int($this->conf[self::CONF_LOGGING_LEVEL])) {
             throw new \Psr\Log\InvalidArgumentException('The logging_level is not an integer.');
         }
-        $this->overrideLoggingLevel = $this->conf['logging_level'];
+        $this->overrideLoggingLevel = $this->conf[self::CONF_LOGGING_LEVEL];
         //@todo do not use $this->conf but set the class properties right here accordingly; and also provide means to set the values otherwise later
         //240709 set later is probably not necessary
     }
@@ -309,7 +309,7 @@ class Logger extends AbstractLogger implements LoggerInterface
             (
                 $level <= max(
                     array(
-                        $this->conf['logging_level'],
+                        $this->conf[self::CONF_LOGGING_LEVEL],
                         $this->overrideLoggingLevel,
                         // $this->conf['error_hack_from_get'], //set potentially as GET parameter
                         //  $ERROR_HACK, //set as variable in the application script
@@ -318,7 +318,7 @@ class Logger extends AbstractLogger implements LoggerInterface
             )
             // or log page_speed everytime error_number equals 6 and
             // logging_level_page_speed has at least the severity of logging_level
-            || (($error_number === 6) && ($this->conf['logging_level_page_speed'] <= $this->conf['logging_level']))
+            || (($error_number === 6) && ($this->conf['logging_level_page_speed'] <= $this->conf[self::CONF_LOGGING_LEVEL]))
         ) {
             $RUNNING_TIME_PREVIOUS = $this->runningTime;
             if (((($this->runningTime = round($this->time->getmicrotime() - $this->time->getPageTimestamp(), 4)) - $RUNNING_TIME_PREVIOUS) > $this->conf['log_profiling_step']) && $this->conf['log_profiling_step']) {

--- a/test.php
+++ b/test.php
@@ -1,18 +1,20 @@
 <?php
 
+use Seablast\Logger\Logger;
+
 require 'vendor/autoload.php';
 
 // Initialize the logger
 $conf = array(
-    'error_log_message_type' => 3,
-    'logging_file' => './error_log',
-    'logging_level' => 0, // start with logging almost nothing for purpose of test looping
-    'logging_level_page_speed' => 5,
-    'log_monthly_rotation' => true,
-    'log_profiling_step' => 0.001,
-    'mail_for_admin_enabled' => true,
+    Logger::CONF_ERROR_LOG_MESSAGE_TYPE => 3,
+    Logger::CONF_LOGGING_FILE => './error_log', // extension .log will be added automatically
+    Logger::CONF_LOGGING_LEVEL => 0, // start with logging almost nothing for purpose of test looping
+    Logger::CONF_LOGGING_LEVEL_PAGE_SPEED => 5,
+    Logger::CONF_LOG_MONTHLY_ROTATION => true,
+    Logger::CONF_LOG_PROFILING_STEP => 0.00048,
+    Logger::CONF_MAIL_FOR_ADMIN_ENABLED => false,
 );
-$logger = new Seablast\Logger\Logger($conf);
+$logger = new Logger($conf);
 
 $severities = array('emergency', 'alert', 'critical', 'error', 'warning', 'notice', 'info', 'debug');
 // Loop through levels 1 to 5


### PR DESCRIPTION
### Added
- Class configuration is managed by an array where field names are defined as constants to enable IDE hints.

### Fixed
- argument `$level` of method `log` accepts also strings defined in Psr\Log\LogLevel as required by [PSR-3](https://www.php-fig.org/psr/psr-3/)