### PR TITLE
Stable version for PHP/7.1+ || PHP/8.x

### DIFF
--- a/.github/workflows/php-composer-dependencies.yml
+++ b/.github/workflows/php-composer-dependencies.yml
@@ -21,5 +21,4 @@ jobs:
     uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@main
     with:
       # JSON
-      php-version: '["5.3", "5.4", "5.5", "5.6", "7.0", "7.1", "7.2", "7.3", "7.4"]'
-      # TODO: add , "8.0", "8.1", "8.2", "8.3" when 5.x removed
+      php-version: '["7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]'

--- a/.github/workflows/php-composer-dependencies.yml
+++ b/.github/workflows/php-composer-dependencies.yml
@@ -21,4 +21,4 @@ jobs:
     uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@main
     with:
       # JSON
-      php-version: '["7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]'
+      php-version: '["7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added` for new features
 
 ### `Changed` for changes in existing functionality
+Stable version for `"php": "^7.1 || ^8.0"`. (As of PHP 7.1.0 visibility modifiers are allowed for class constants.)
 
 ### `Deprecated` for soon-to-be removed features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added` for new features
 
 ### `Changed` for changes in existing functionality
-Stable version for `"php": "^7.1 || ^8.0"`. (As of PHP 7.1.0 visibility modifiers are allowed for class constants.)
 
 ### `Deprecated` for soon-to-be removed features
 
@@ -17,6 +16,9 @@ Stable version for `"php": "^7.1 || ^8.0"`. (As of PHP 7.1.0 visibility modifier
 ### `Fixed` for any bugfixes
 
 ### `Security` in case of vulnerabilities
+
+## [2.0] - 2024-07-27
+Stable version for `"php": "^7.1 || ^8.0"`. (As of PHP 7.1.0 visibility modifiers are allowed for class constants.)
 
 ## [1.0] - 2024-07-27
 Stable version for `"php": "^5.3 || ^7.0"`
@@ -31,7 +33,8 @@ Stable version for `"php": "^5.3 || ^7.0"`
 ## [0.1] - 2024-07-12
 - A [PSR-3](https://www.php-fig.org/psr/psr-3/) compliant logger with adjustable verbosity (based on Backyard\BackyardError)
 
-[Unreleased]: https://github.com/WorkOfStan/seablast-logger/compare/v1.0...HEAD
+[Unreleased]: https://github.com/WorkOfStan/seablast-logger/compare/v2.0...HEAD
+[2.0]: https://github.com/WorkOfStan/seablast-logger/compare/v1.0...v2.0
 [1.0]: https://github.com/WorkOfStan/seablast-logger/compare/v0.2...v1.0
 [0.2]: https://github.com/WorkOfStan/seablast-logger/compare/v0.1...v0.2
 [0.1]: https://github.com/WorkOfStan/seablast-logger/releases/tag/v0.1

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,9 @@
     "description": "A PSR-3 compliant logger with adjustable verbosity.",
     "type": "library",
     "require": {
-        "php": "^5.3 || ^7.0",
+        "php": "^7.0 || ^8.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "tracy/tracy": "^2.3.12"
+        "tracy/tracy": "^2.5.9"
     },
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,9 @@
     "description": "A PSR-3 compliant logger with adjustable verbosity.",
     "type": "library",
     "require": {
-        "php": "^7.0 || ^8.0",
+        "php": "^7.1 || ^8.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "tracy/tracy": "^2.5.9"
+        "tracy/tracy": "^2.6.0"
     },
     "license": "MIT",
     "authors": [

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -13,9 +13,7 @@ use Seablast\Logger\LoggerTime;
 class Logger extends AbstractLogger implements LoggerInterface
 {
     // Define constants for configuration keys
-    // phpcs:disable PSR12.Properties.ConstantVisibility.NotFound
-    // todo remove phpcs exception when PHP/5 support removed
-    const CONF_ERROR_LOG_MESSAGE_TYPE = 'error_log_message_type';
+    public const CONF_ERROR_LOG_MESSAGE_TYPE = 'error_log_message_type';
     const CONF_LOGGING_FILE = 'logging_file';
     const CONF_LOGGING_LEVEL = 'logging_level';
     const CONF_LOGGING_LEVEL_NAME = 'logging_level_name';
@@ -23,7 +21,6 @@ class Logger extends AbstractLogger implements LoggerInterface
     const CONF_LOG_MONTHLY_ROTATION = 'log_monthly_rotation';
     const CONF_LOG_PROFILING_STEP = 'log_profiling_step';
     const CONF_MAIL_FOR_ADMIN_ENABLED = 'mail_for_admin_enabled';
-    // phpcs:enable
 
     /** @var array<mixed> int,string,bool,array */
     protected $conf = array();
@@ -125,9 +122,8 @@ class Logger extends AbstractLogger implements LoggerInterface
      * @param array<int> $context
      * @return void
      */
-    public function emergency($message, array $context = array())
+    public function emergency($message, array $context = array()): void
     {
-        //TODO when adding PHP/8 support, add :void to the inherited methods and remove PHP/5 support
         $this->log(0, $message, $context);
     }
 
@@ -141,7 +137,7 @@ class Logger extends AbstractLogger implements LoggerInterface
      * @param array<int> $context
      * @return void
      */
-    public function alert($message, array $context = array())
+    public function alert($message, array $context = array()): void
     {
         $this->log(1, $message, $context);
     }
@@ -155,7 +151,7 @@ class Logger extends AbstractLogger implements LoggerInterface
      * @param array<int> $context
      * @return void
      */
-    public function critical($message, array $context = array())
+    public function critical($message, array $context = array()): void
     {
         $this->log(1, $message, $context);
     }
@@ -168,7 +164,7 @@ class Logger extends AbstractLogger implements LoggerInterface
      * @param array<int> $context
      * @return void
      */
-    public function error($message, array $context = array())
+    public function error($message, array $context = array()): void
     {
         $this->log(2, $message, $context);
     }
@@ -183,7 +179,7 @@ class Logger extends AbstractLogger implements LoggerInterface
      * @param array<int> $context
      * @return void
      */
-    public function warning($message, array $context = array())
+    public function warning($message, array $context = array()): void
     {
         $this->log(3, $message, $context);
     }
@@ -195,7 +191,7 @@ class Logger extends AbstractLogger implements LoggerInterface
      * @param array<int> $context
      * @return void
      */
-    public function notice($message, array $context = array())
+    public function notice($message, array $context = array()): void
     {
         $this->log(4, $message, $context);
     }

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -14,13 +14,13 @@ class Logger extends AbstractLogger implements LoggerInterface
 {
     // Define constants for configuration keys
     public const CONF_ERROR_LOG_MESSAGE_TYPE = 'error_log_message_type';
-    const CONF_LOGGING_FILE = 'logging_file';
-    const CONF_LOGGING_LEVEL = 'logging_level';
-    const CONF_LOGGING_LEVEL_NAME = 'logging_level_name';
-    const CONF_LOGGING_LEVEL_PAGE_SPEED = 'logging_level_page_speed';
-    const CONF_LOG_MONTHLY_ROTATION = 'log_monthly_rotation';
-    const CONF_LOG_PROFILING_STEP = 'log_profiling_step';
-    const CONF_MAIL_FOR_ADMIN_ENABLED = 'mail_for_admin_enabled';
+    public const CONF_LOGGING_FILE = 'logging_file';
+    public const CONF_LOGGING_LEVEL = 'logging_level';
+    public const CONF_LOGGING_LEVEL_NAME = 'logging_level_name';
+    public const CONF_LOGGING_LEVEL_PAGE_SPEED = 'logging_level_page_speed';
+    public const CONF_LOG_MONTHLY_ROTATION = 'log_monthly_rotation';
+    public const CONF_LOG_PROFILING_STEP = 'log_profiling_step';
+    public const CONF_MAIL_FOR_ADMIN_ENABLED = 'mail_for_admin_enabled';
 
     /** @var array<mixed> int,string,bool,array */
     protected $conf = array();
@@ -88,7 +88,7 @@ class Logger extends AbstractLogger implements LoggerInterface
      * @param int $newLevel
      * @return void
      */
-    public function logAtLeastToLevel(int $newLevel)
+    public function logAtLeastToLevel(int $newLevel): void
     {
         if (!is_int($newLevel)) {
             throw new \Psr\Log\InvalidArgumentException('The variable $newLevel is not an integer.');
@@ -99,7 +99,7 @@ class Logger extends AbstractLogger implements LoggerInterface
     /**
      * @return float
      */
-    public function getLastRunningTime()
+    public function getLastRunningTime(): float
     {
         return $this->runningTime;
     }
@@ -110,7 +110,7 @@ class Logger extends AbstractLogger implements LoggerInterface
      * @param int|string $user
      * @return void
      */
-    public function setUser($user)
+    public function setUser($user): void
     {
         $this->user = (string) $user;
     }
@@ -205,7 +205,7 @@ class Logger extends AbstractLogger implements LoggerInterface
      * @param array<int> $context
      * @return void
      */
-    public function info($message, array $context = array())
+    public function info($message, array $context = array()): void
     {
         $this->log(4, $message, $context);
     }
@@ -217,7 +217,7 @@ class Logger extends AbstractLogger implements LoggerInterface
      * @param array<int> $context
      * @return void
      */
-    public function debug($message, array $context = array())
+    public function debug($message, array $context = array()): void
     {
         $this->log(5, $message, $context);
     }
@@ -261,7 +261,7 @@ class Logger extends AbstractLogger implements LoggerInterface
      *  1001 Establish correct error_number
      *
      */
-    public function log($level, $message, array $context = array())
+    public function log($level, $message, array $context = array()): void
     {
         //TODO add variable $line - it should always be called as basename(__FILE__)."#".__LINE__ ,
         //so it's clear which line of the source code triggered the call


### PR DESCRIPTION
- A [PSR-3](https://www.php-fig.org/psr/psr-3/) compliant logger with adjustable verbosity (based on Backyard\BackyardError).
-  Class configuration is managed by an array where field names are defined as constants to enable IDE hints.
- Stable version for `"php": "^7.1 || ^8.0"`.