### PR TITLE
Fix formatting with Prettier, remove obsolete code, and enforce stricter type checks.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,5 @@ updates:
     # Location of package manifests
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every weekday
+      # Check for updates to GitHub Actions every week
       interval: "weekly"

--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -18,24 +18,24 @@
 ############################
 # Super-linter Rules by id #
 ############################
-MD004: false                  # Unordered list style
+MD004: false # Unordered list style
 MD007:
-  indent: 2                   # Unordered list indentation
+  indent: 2 # Unordered list indentation
 MD013:
-  line_length: 808            # Line length 80 is far too short
+  line_length: 808 # Line length 80 is far too short
 MD026:
-  punctuation: ".,;:!。，；:"  # List of not allowed
-MD029: false                  # Ordered list item prefix
-MD033: false                  # Allow inline HTML
-MD036: false                  # Emphasis used instead of a heading
+  punctuation: ".,;:!。，；:" # List of not allowed
+MD029: false # Ordered list item prefix
+MD033: false # Allow inline HTML
+MD036: false # Emphasis used instead of a heading
 
 ##############################
 # Super-linter Rules by tags #
 ##############################
-blank_lines: false  # Error on blank lines
+blank_lines: false # Error on blank lines
 
 ########################
 # Seablast Rules by id #
 ########################
 # Multiple heading with the same content (in CHANGELOG.md)
-MD024: false                 # No-duplicate-heading
+MD024: false # No-duplicate-heading

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,11 +18,11 @@ on:
   push:
     branches-ignore:
       # notest branches to ignore testing of partial online commits
-      - 'notest/**'
+      - "notest/**"
   pull_request:
     branches-ignore:
       # notest branches to ignore testing of partial online commits
-      - 'notest/**'
+      - "notest/**"
 
 permissions:
   contents: read

--- a/.github/workflows/overtrue-phplint.yml
+++ b/.github/workflows/overtrue-phplint.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches-ignore:
       # notest branches to ignore testing of partial online commits
-      - 'notest/**'
+      - "notest/**"
   pull_request:
     branches-ignore:
       # notest branches to ignore testing of partial online commits
-      - 'notest/**'
+      - "notest/**"
 
 permissions:
   contents: read

--- a/.github/workflows/php-composer-dependencies.yml
+++ b/.github/workflows/php-composer-dependencies.yml
@@ -5,12 +5,12 @@ on:
   push:
     branches-ignore:
       # notest branches to ignore testing of partial online commits
-      - 'notest/**'
+      - "notest/**"
 
   pull_request:
     branches-ignore:
       # notest branches to ignore testing of partial online commits
-      - 'notest/**'
+      - "notest/**"
 
 permissions:
   contents: read

--- a/.github/workflows/phpcbf.yml
+++ b/.github/workflows/phpcbf.yml
@@ -5,10 +5,10 @@ name: PHPCBF
 on:
   push:
     branches:
-      - 'phpcbf*'
+      - "phpcbf*"
   pull_request:
     branches:
-      - 'phpcbf*'
+      - "phpcbf*"
 
 permissions:
   contents: write

--- a/.github/workflows/prettier-fix.yml
+++ b/.github/workflows/prettier-fix.yml
@@ -1,0 +1,20 @@
+---
+name: Prettier-fix
+on: [pull_request, push]
+
+permissions:
+  contents: write
+
+jobs:
+  prettier-fix:
+    # Run only if the actor is not the GitHub Actions bot
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    # Limit the running time
+    timeout-minutes: 10
+    steps:
+      - name: Invoke the Prettier fix
+        # Use the latest commit in the main branch.
+        uses: WorkOfStan/prettier-fix@v1.0.3
+        #with:
+        #  node-version: "20"

--- a/.github/workflows/prettier-fix.yml
+++ b/.github/workflows/prettier-fix.yml
@@ -1,20 +1,25 @@
 ---
 name: Prettier-fix
-on: [pull_request, push]
+on:
+  push:
+    branches-ignore:
+      # notest branches to ignore testing of partial online commits
+      - "notest/**"
+  pull_request:
+    branches-ignore:
+      # notest branches to ignore testing of partial online commits
+      - "notest/**"
 
 permissions:
   contents: write
 
 jobs:
   prettier-fix:
-    # Run only if the actor is not the GitHub Actions bot
-    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     # Limit the running time
     timeout-minutes: 10
     steps:
       - name: Invoke the Prettier fix
-        # Use the latest commit in the main branch.
-        uses: WorkOfStan/prettier-fix@v1.0.3
-        #with:
-        #  node-version: "20"
+        uses: WorkOfStan/prettier-fix@v1.1.0
+        with:
+          commit-changes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### `Added` for new features
 
 ### `Changed` for changes in existing functionality
@@ -18,23 +20,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Security` in case of vulnerabilities
 
 ## [2.0.1] - 2024-08-10
+
 ### Added
+
 - PHPUnit test for class LoggerTime
 
 ## [2.0] - 2024-07-27
+
 Stable version for `"php": "^7.1 || ^8.0"`. (As of PHP 7.1.0 visibility modifiers are allowed for class constants.)
 
 ## [1.0] - 2024-07-27
+
 Stable version for `"php": "^5.3 || ^7.0"`
 
 ## [0.2] - 2024-07-23
+
 ### Added
+
 - Class configuration is managed by an array where field names are defined as constants to enable IDE hints.
 
 ### Fixed
+
 - argument `$level` of method `log` accepts also strings defined in Psr\Log\LogLevel as required by [PSR-3](https://www.php-fig.org/psr/psr-3/)
 
 ## [0.1] - 2024-07-12
+
 - A [PSR-3](https://www.php-fig.org/psr/psr-3/) compliant logger with adjustable verbosity (based on Backyard\BackyardError)
 
 [Unreleased]: https://github.com/WorkOfStan/seablast-logger/compare/v2.0.1...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - LoggerTime::getmicrotime() condition addressing PHP<5
+- LoggerTimeTest::testGetmicrotime() testing Seablast\Logger\LoggerTime::getmicrotime as unnecessary
 
 ## [2.0.1] - 2024-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - prettier-fix
 
+### Changed
+
+- update Logger.php limited result-exception scope
+- more strict type checks
+
 ### Removed
 
 - LoggerTime::getmicrotime() condition addressing PHP<5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
+## [2.0.2] - 2024-12-10
+
+### Added
+
+- prettier-fix
+
+### Removed
+
+- LoggerTime::getmicrotime() condition addressing PHP<5
+
 ## [2.0.1] - 2024-08-10
 
 ### Added
@@ -47,7 +57,8 @@ Stable version for `"php": "^5.3 || ^7.0"`
 
 - A [PSR-3](https://www.php-fig.org/psr/psr-3/) compliant logger with adjustable verbosity (based on Backyard\BackyardError)
 
-[Unreleased]: https://github.com/WorkOfStan/seablast-logger/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/WorkOfStan/seablast-logger/compare/v2.0.2...HEAD
+[2.0.2]: https://github.com/WorkOfStan/seablast-logger/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/WorkOfStan/seablast-logger/compare/v2.0...v2.0.1
 [2.0]: https://github.com/WorkOfStan/seablast-logger/compare/v1.0...v2.0
 [1.0]: https://github.com/WorkOfStan/seablast-logger/compare/v0.2...v1.0

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # seablast-logger
+
 A [PSR-3](http://www.php-fig.org/psr/psr-3/) compliant logger with adjustable verbosity.
 
 The logging level verbosity can be tailored to suit different environments.
@@ -6,6 +7,7 @@ For instance, in a development environment, the logger can be configured to log 
 Simply adjust the verbosity.
 
 The `logging_level` is the most important setting. These parameters can be configured when instantiating the logger:
+
 ```php
 use Seablast\Logger\Logger;
 $conf = array(
@@ -29,9 +31,11 @@ $conf = array(
 );
 $logger = new Logger($conf);
 ```
+
 See [test.php](test.php) for usage.
 
 By default the logger logs the following levels of information:
+
 - fatal
 - error
 - warning
@@ -39,15 +43,18 @@ By default the logger logs the following levels of information:
 - debug
 
 And ignores
+
 - speed
 
 Note: Outputting log messages to the screen is not supported.
 
 ## Runtime adjustment
+
 - method logAtLeastToLevel(int $level) may change the verbosity level above the level set when instatiating.
 - method setUser(int|string $user) may add the user identification to the error messages
 
 ## Tracy\Logger::log wrapper
+
 Since Nette\Tracy::v2.6.0, i.e. `"php": ">=7.1"` it is possible to use a PSR-3 adapter, allowing for integration of [seablast/logger](https://github.com/WorkOfStan/seablast-logger).
 
 ```php

--- a/Test/LoggerTimeTest.php
+++ b/Test/LoggerTimeTest.php
@@ -37,18 +37,6 @@ class LoggerTimeTest extends TestCase
     }
 
     /**
-     * @covers Seablast\Logger\LoggerTime::getmicrotime
-     *
-     * @return void
-     */
-    public function testGetmicrotime(): void
-    {
-        // I want to test it anyway, just in case.
-        /** @phpstan-ignore function.alreadyNarrowedType, method.alreadyNarrowedType */
-        $this->assertTrue(is_float($this->object->getmicrotime()));
-    }
-
-    /**
      * @covers Seablast\Logger\LoggerTime::getRunningTime
      *
      * @return void

--- a/Test/LoggerTimeTest.php
+++ b/Test/LoggerTimeTest.php
@@ -43,6 +43,8 @@ class LoggerTimeTest extends TestCase
      */
     public function testGetmicrotime(): void
     {
+        // I want to test it anyway, just in case.
+        /** @phpstan-ignore function.alreadyNarrowedType, method.alreadyNarrowedType */
         $this->assertTrue(is_float($this->object->getmicrotime()));
     }
 

--- a/composer.json
+++ b/composer.json
@@ -1,40 +1,44 @@
 {
-    "name": "seablast/logger",
-    "description": "A PSR-3 compliant logger with adjustable verbosity.",
-    "type": "library",
-    "require": {
-        "php": "^7.1 || ^8.0",
-        "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "tracy/tracy": "^2.6.0"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^6 || ^7 || ^8 || ^9 || ^10 || ^11"
-    },
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Stanislav Rejthar",
-            "email": "rejthar@stanislavrejthar.com"
-        }
-    ],
-    "support": {
-        "email": "rejthar@stanislavrejthar.com",
-        "issues": "https://github.com/WorkOfStan/seablast-logger/issues",
-        "source": "https://github.com/WorkOfStan/seablast-logger"
-    },
-    "minimum-stability": "stable",
-    "prefer-stable": true,
-    "config": {
-        "sort-packages": true
-    },
-    "autoload": {
-        "psr-4": {
-            "Seablast\\Logger\\": ["src/"]
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Seablast\\Logger\\Test\\": ["Test/"]
-        }
+  "name": "seablast/logger",
+  "description": "A PSR-3 compliant logger with adjustable verbosity.",
+  "type": "library",
+  "require": {
+    "php": "^7.1 || ^8.0",
+    "psr/log": "^1.0 || ^2.0 || ^3.0",
+    "tracy/tracy": "^2.6.0"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^6 || ^7 || ^8 || ^9 || ^10 || ^11"
+  },
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Stanislav Rejthar",
+      "email": "rejthar@stanislavrejthar.com"
     }
+  ],
+  "support": {
+    "email": "rejthar@stanislavrejthar.com",
+    "issues": "https://github.com/WorkOfStan/seablast-logger/issues",
+    "source": "https://github.com/WorkOfStan/seablast-logger"
+  },
+  "minimum-stability": "stable",
+  "prefer-stable": true,
+  "config": {
+    "sort-packages": true
+  },
+  "autoload": {
+    "psr-4": {
+      "Seablast\\Logger\\": [
+        "src/"
+      ]
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Seablast\\Logger\\Test\\": [
+        "Test/"
+      ]
+    }
+  }
 }

--- a/conf/phpstan.app.neon
+++ b/conf/phpstan.app.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 9
+    level: max
     excludePaths:
         analyse:
           - ../vendor

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -93,9 +93,9 @@ class Logger extends AbstractLogger implements LoggerInterface
      */
     public function logAtLeastToLevel(int $newLevel): void
     {
-        if (!is_int($newLevel)) {
-            throw new \Psr\Log\InvalidArgumentException('The variable $newLevel is not an integer.');
-        }
+//        if (!is_int($newLevel)) {
+//            throw new \Psr\Log\InvalidArgumentException('The variable $newLevel is not an integer.');
+//        }
         $this->overrideLoggingLevel = (int) $newLevel;
     }
 
@@ -276,6 +276,7 @@ class Logger extends AbstractLogger implements LoggerInterface
     {
         //TODO add variable $line - it should always be called as basename(__FILE__)."#".__LINE__ ,
         //so it's clear which line of the source code triggered the call
+        /** @phpstan-ignore function.alreadyNarrowedType */
         if (!is_string($message)) {
             $message = 'wrong message type ' . gettype($message) . ': Logger->log(' . print_r($level, true) . ','
                 . print_r($message, true) . ')';
@@ -336,15 +337,29 @@ class Logger extends AbstractLogger implements LoggerInterface
                 $message = 'SLOWSTEP ' . $message; //110812, PROFILING
             }
 
+            // checks for the static code analysis
+            if (!is_array($this->conf[self::CONF_LOGGING_LEVEL_NAME])) {
+                $this->conf[self::CONF_LOGGING_LEVEL_NAME] = [];
+            }
+            if (
+                !is_string($this->conf[self::CONF_LOGGING_LEVEL_NAME][$level])
+            ) {
+                $this->conf[self::CONF_LOGGING_LEVEL_NAME][$level] = 'non-string';
+            }
             $message_prefix = '[' . date('d-M-Y H:i:s') . '] [' . $this->conf[self::CONF_LOGGING_LEVEL_NAME][$level]
-                . '] [' . $error_number . '] [' . $_SERVER['SCRIPT_FILENAME'] . '] ['
+                . '] [' . $error_number . '] ['
+                . ((isset($_SERVER['SCRIPT_FILENAME']) && is_string($_SERVER['SCRIPT_FILENAME'])) //
+                ? $_SERVER['SCRIPT_FILENAME'] : 'no-script')
+                . '] ['
                 . $this->user . '@'
                 // PHPUnit test (CLI) does not set REMOTE_ADDR
                 // TODO what if gethostbyaddr can't resolve the IP? And wouldn't be faster to log IP?
-                . (isset($_SERVER['REMOTE_ADDR']) ? gethostbyaddr($_SERVER['REMOTE_ADDR']) : '-')
+                . ((isset($_SERVER['REMOTE_ADDR']) && is_string($_SERVER['REMOTE_ADDR'])) //
+                ? gethostbyaddr($_SERVER['REMOTE_ADDR']) : '-')
                 . '] [' . $this->runningTime . '] ['
                 // PHPUnit test (CLI) does not set REQUEST_URI
-                . (isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '-')
+                . ((isset($_SERVER['REQUEST_URI']) && is_string($_SERVER['REQUEST_URI'])) //
+                ? $_SERVER['REQUEST_URI'] : '-')
                 . '] ';
             $result = true; //it could eventually be reset to false after calling error_log()
             // $logging_file not set and it should be
@@ -354,6 +369,9 @@ class Logger extends AbstractLogger implements LoggerInterface
             } else {
                 $messageType = ($this->conf[self::CONF_ERROR_LOG_MESSAGE_TYPE] === 0)
                     ? $this->conf[self::CONF_ERROR_LOG_MESSAGE_TYPE] : 3;
+                if (!is_string($this->conf[self::CONF_LOGGING_FILE])) {
+                    $this->conf[self::CONF_LOGGING_FILE] = './error_log'; // a forced default
+                }
                 $result = $this->conf[self::CONF_LOG_MONTHLY_ROTATION]
                     ? error_log(
                         $message_prefix . $message . (($messageType != 0) ? PHP_EOL : ''),
@@ -370,10 +388,17 @@ class Logger extends AbstractLogger implements LoggerInterface
                 throw new ErrorLogFailureException('error_log() failed');
             }
             // mailto admin. 'mail_for_admin_enabled' has to be an email
-            if ($level === 1 && $this->conf[self::CONF_MAIL_FOR_ADMIN_ENABLED]) {
-                $result2 = error_log($message_prefix . $message . PHP_EOL, 1, $this->conf[self::CONF_MAIL_FOR_ADMIN_ENABLED]);
+            if (
+                $level === 1 && $this->conf[self::CONF_MAIL_FOR_ADMIN_ENABLED] //
+                && is_string($this->conf[self::CONF_MAIL_FOR_ADMIN_ENABLED])
+            ) {
+                $result2 = error_log(
+                    $message_prefix . $message . PHP_EOL,
+                    1,
+                    $this->conf[self::CONF_MAIL_FOR_ADMIN_ENABLED]
+                );
                 if ($result2 === false) {
-                    throw new ErrorLogFailureException('error_log() failed');
+                    throw new ErrorLogFailureException('error_log() mailing failed');
                 }
             }
         }

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -93,9 +93,6 @@ class Logger extends AbstractLogger implements LoggerInterface
      */
     public function logAtLeastToLevel(int $newLevel): void
     {
-//        if (!is_int($newLevel)) {
-//            throw new \Psr\Log\InvalidArgumentException('The variable $newLevel is not an integer.');
-//        }
         $this->overrideLoggingLevel = (int) $newLevel;
     }
 
@@ -276,12 +273,11 @@ class Logger extends AbstractLogger implements LoggerInterface
     {
         //TODO add variable $line - it should always be called as basename(__FILE__)."#".__LINE__ ,
         //so it's clear which line of the source code triggered the call
-        /** @phpstan-ignore function.alreadyNarrowedType */
-        if (!is_string($message)) {
-            $message = 'wrong message type ' . gettype($message) . ': Logger->log(' . print_r($level, true) . ','
-                . print_r($message, true) . ')';
-            $this->error($message);
-        }
+        //if (!is_string($message)) {
+        //    $message = 'wrong message type ' . gettype($message) . ': Logger->log(' . print_r($level, true) . ','
+        //        . print_r($message, true) . ')';
+        //    $this->error($message);
+        //}
         // psr log levels to numbered severity
         $psr2int = [
             LogLevel::EMERGENCY => 0,
@@ -353,7 +349,7 @@ class Logger extends AbstractLogger implements LoggerInterface
                 . '] ['
                 . $this->user . '@'
                 // PHPUnit test (CLI) does not set REMOTE_ADDR
-                // TODO what if gethostbyaddr can't resolve the IP? And wouldn't be faster to log IP?
+                // TODO what if gethostbyaddr can't resolve the IP? And wouldn't be faster to just log IP?
                 . ((isset($_SERVER['REMOTE_ADDR']) && is_string($_SERVER['REMOTE_ADDR'])) //
                 ? gethostbyaddr($_SERVER['REMOTE_ADDR']) : '-')
                 . '] [' . $this->runningTime . '] ['

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -309,8 +309,6 @@ class Logger extends AbstractLogger implements LoggerInterface
             ? 0
             : (isset($context['error_number']) ? (int) $context['error_number'] : (int) reset($context));
 
-        $result = true; //it could eventually be reset to false after calling error_log()
-
         if (
             // log 0=unknown/default 1=fatal 2=error 3=warning 4=info 5=debug 6=speed according to $level
             (
@@ -348,6 +346,7 @@ class Logger extends AbstractLogger implements LoggerInterface
                 // PHPUnit test (CLI) does not set REQUEST_URI
                 . (isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '-')
                 . '] ';
+            $result = true; //it could eventually be reset to false after calling error_log()
             // $logging_file not set and it should be
             if (($this->conf[self::CONF_ERROR_LOG_MESSAGE_TYPE] == 3) && !$this->conf[self::CONF_LOGGING_FILE]) {
                 // so write into the default destination
@@ -367,13 +366,16 @@ class Logger extends AbstractLogger implements LoggerInterface
                         "{$this->conf[self::CONF_LOGGING_FILE]}.log"
                     ); // writes into one file
             }
+            if ($result === false) {
+                throw new ErrorLogFailureException('error_log() failed');
+            }
             // mailto admin. 'mail_for_admin_enabled' has to be an email
             if ($level === 1 && $this->conf[self::CONF_MAIL_FOR_ADMIN_ENABLED]) {
-                error_log($message_prefix . $message . PHP_EOL, 1, $this->conf[self::CONF_MAIL_FOR_ADMIN_ENABLED]);
+                $result2 = error_log($message_prefix . $message . PHP_EOL, 1, $this->conf[self::CONF_MAIL_FOR_ADMIN_ENABLED]);
+                if ($result2 === false) {
+                    throw new ErrorLogFailureException('error_log() failed');
+                }
             }
-        }
-        if ($result === false) {
-            throw new ErrorLogFailureException('error_log() failed');
         }
     }
     /** Alternative way:

--- a/src/LoggerTime.php
+++ b/src/LoggerTime.php
@@ -31,10 +31,7 @@ class LoggerTime
      */
     public function getPageTimestamp(): float
     {
-//        if (is_null($this->pageTimestamp)) {
-//            $this->pageTimestamp = $this->getmicrotime(); // initialisation, so that it can't return null
-//        }
-        // Since the constructor initializes $pageTimestamp, there's no need to check and initialize it again. 
+        // Since the constructor initializes $pageTimestamp, there's no need to check and initialize it again.
         return $this->pageTimestamp;
     }
 

--- a/src/LoggerTime.php
+++ b/src/LoggerTime.php
@@ -6,8 +6,8 @@ namespace Seablast\Logger;
 
 class LoggerTime
 {
-    /** @var ?float */
-    private $pageTimestamp = null;
+    /** @var float */
+    private $pageTimestamp;
 
     public function __construct()
     {
@@ -23,10 +23,6 @@ class LoggerTime
      */
     public function getmicrotime(): float
     {
-        if (version_compare((string) phpversion(), '5.0.0') == -1) {
-            list($usec, $sec) = explode(' ', microtime());
-            return (float) $usec + (float) $sec;
-        }
         return microtime(true);
     }
 
@@ -35,9 +31,10 @@ class LoggerTime
      */
     public function getPageTimestamp(): float
     {
-        if (is_null($this->pageTimestamp)) {
-            $this->pageTimestamp = $this->getmicrotime(); // initialisation, so that it can't return null
-        }
+//        if (is_null($this->pageTimestamp)) {
+//            $this->pageTimestamp = $this->getmicrotime(); // initialisation, so that it can't return null
+//        }
+        // Since the constructor initializes $pageTimestamp, there's no need to check and initialize it again. 
         return $this->pageTimestamp;
     }
 

--- a/test.php
+++ b/test.php
@@ -18,7 +18,7 @@ $conf = [
 ];
 $logger = new Logger($conf);
 
-echo "<h1>See what appears in the {$conf[Logger::CONF_LOGGING_FILE]}" . date('Y-m') . ".log</h1>";
+echo "<h1>Compare to what appears in the {$conf[Logger::CONF_LOGGING_FILE]}" . date('Y-m') . ".log</h1>";
 $severities = ['emergency', 'alert', 'critical', 'error', 'warning', 'notice', 'info', 'debug'];
 // Loop through levels 1 to 5
 for ($level = 1; $level <= 5; $level++) {

--- a/test.php
+++ b/test.php
@@ -18,11 +18,12 @@ $conf = [
 ];
 $logger = new Logger($conf);
 
+echo "<h1>See what appears in the {$conf[Logger::CONF_LOGGING_FILE]}" . date('Y-m') . ".log</h1>";
 $severities = ['emergency', 'alert', 'critical', 'error', 'warning', 'notice', 'info', 'debug'];
 // Loop through levels 1 to 5
 for ($level = 1; $level <= 5; $level++) {
     // Set the logging level
-    echo "<h1>logAtLeastToLevel({$level})</h1>";
+    echo "<h2>logAtLeastToLevel({$level})</h2>";
     $logger->logAtLeastToLevel($level);
 
     foreach ($severities as $severity) {


### PR DESCRIPTION
### Added

- prettier-fix

### Changed

- update Logger.php limited result-exception scope
- more strict type checks

### Removed

- LoggerTime::getmicrotime() condition addressing PHP<5
- LoggerTimeTest::testGetmicrotime() testing Seablast\Logger\LoggerTime::getmicrotime as unnecessary
