### PR TITLE
fix: remove support below PHP/7.2, because of CVE-2026-24765

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,5 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every month
       interval: "monthly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -53,7 +53,7 @@ jobs:
 
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
   php-composer-unit-stan:
-    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.8
+    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.9
     with:
       # JSON
       php-version: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]'
@@ -95,6 +95,6 @@ jobs:
 
   super-linter:
     needs: phpcs-phpcbf
-    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.8
+    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.9
     with:
       runs-on: "ubuntu-latest"

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -31,14 +31,17 @@ jobs:
     # Limit the running time
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }} # checkout PR HEAD commit
-          fetch-depth: 0 # required for merge-base check
+          # checkout PR HEAD commit
+          ref: ${{ github.event.pull_request.head.sha }}
+          # required for merge-base check
+          fetch-depth: 0
           persist-credentials: false
       - uses: commit-check/commit-check-action@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # use GITHUB_TOKEN because use of pr-comments
+          # use GITHUB_TOKEN because use of pr-comments
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           message: true
           # to accept dependabot/github_actions/*
@@ -50,10 +53,10 @@ jobs:
 
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
   php-composer-unit-stan:
-    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.7
+    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.8
     with:
       # JSON
-      php-version: '["7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]'
+      php-version: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]'
       # OPTIONAL path with the default database configuration
       #phinx-config: "./conf/phinx.dist.php"
       # OPTIONAL path where the app code is looking for the database configuration
@@ -92,6 +95,6 @@ jobs:
 
   super-linter:
     needs: phpcs-phpcbf
-    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.7
+    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.8
     with:
       runs-on: "ubuntu-latest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed` for changes in existing functionality
 
-- package limited to the tested PHP versions, i.e. "php": ">=7.1 <8.5"
-- GitHub Actions version bump to super-linter v8.1.0
-
 ### `Deprecated` for soon-to-be removed features
 
 ### `Removed` for now removed features
@@ -21,6 +18,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed` for any bugfixes
 
 ### `Security` in case of vulnerabilities
+
+## [2.0.5] - 2026-03-01
+
+fix: remove support below PHP/7.2, because of CVE-2026-24765
+
+### Changed
+
+- package limited to the tested PHP versions, i.e. "php": ">=7.2 <8.6"
+- GitHub Actions version bump to super-linter v8.5.0
+
+### Security
+
+- fix: remove support below PHP/7.2, because of CVE-2026-24765
 
 ## [2.0.4] - 2025-10-23
 
@@ -83,7 +93,8 @@ Stable version for `"php": "^5.3 || ^7.0"`
 
 - A [PSR-3](https://www.php-fig.org/psr/psr-3/) compliant logger with adjustable verbosity (based on Backyard\BackyardError)
 
-[Unreleased]: https://github.com/WorkOfStan/seablast-logger/compare/v2.0.4...HEAD
+[Unreleased]: https://github.com/WorkOfStan/seablast-logger/compare/v2.0.5...HEAD
+[2.0.5]: https://github.com/WorkOfStan/seablast-logger/compare/v2.0.4...v2.0.5
 [2.0.4]: https://github.com/WorkOfStan/seablast-logger/compare/v2.0.3...v2.0.4
 [2.0.3]: https://github.com/WorkOfStan/seablast-logger/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/WorkOfStan/seablast-logger/compare/v2.0.1...v2.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,18 @@ fix: remove support below PHP/7.2, because of CVE-2026-24765
 
 - package limited to the tested PHP versions, i.e. "php": ">=7.2 <8.6"
 - GitHub Actions version bump to super-linter v8.5.0
+- Logger refactor: replaced legacy protected $conf array with explicit, typed class properties (errorLogMessageType, loggingFile, loggingLevel, loggingLevelName, loggingLevelPageSpeed, logMonthlyRotation, logProfilingStep, mailForAdminEnabled) to improve type safety and static analysis compatibility.
+- Constructor now prefers property defaults and only overrides properties when config keys are present; config values are validated/narrowed before assignment to satisfy PHPStan and avoid unsafe casts.
+- Introduced WebMozart Assert for concise runtime validations where appropriate.
+
+### Added
+
+- PHPStan-friendly type hints and PHPDoc improvements for Logger properties (e.g. array<int,string> for loggingLevelName).
+
+### Fixed
+
+- Resolved PHPStan errors by narrowing mixed config inputs and removing leftover references to the removed $conf property.
+- Ensured php -l and phpunit pass locally across supported PHP versions.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,11 +35,6 @@ fix: remove support below PHP/7.2, because of CVE-2026-24765
 
 - PHPStan-friendly type hints and PHPDoc improvements for Logger properties (e.g. array<int,string> for loggingLevelName).
 
-### Fixed
-
-- Resolved PHPStan errors by narrowing mixed config inputs and removing leftover references to the removed $conf property.
-- Ensured php -l and phpunit pass locally across supported PHP versions.
-
 ### Security
 
 - fix: remove support below PHP/7.2, because of CVE-2026-24765

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
-## [2.0.5] - 2026-03-01
+## [2.0.5] - 2026-03-08
 
 fix: remove support below PHP/7.2, because of CVE-2026-24765
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 WorkOfStan
+Copyright (c) 2024-2026 WorkOfStan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,9 @@
     "tracy/tracy": "^2.9.8 || ^2.10.9 || ^2.11.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.5.52 || ^9 || ^10 || ^11 || ^12"
+    "phpstan/phpstan-webmozart-assert": "^1.2",
+    "phpunit/phpunit": "^8.5.52 || ^9 || ^10 || ^11 || ^12",
+    "webmozart/assert": "^1.11"
   },
   "license": "MIT",
   "authors": [

--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,8 @@
     "tracy/tracy": "^2.9.8 || ^2.10.9 || ^2.11.0"
   },
   "require-dev": {
-    "phpstan/phpstan-webmozart-assert": "^1.2",
     "phpunit/phpunit": "^8.5.52 || ^9 || ^10 || ^11 || ^12",
-    "webmozart/assert": "^1.11"
+    "webmozart/assert": "^1.11 || ^1.12 || ^2.1.6"
   },
   "license": "MIT",
   "authors": [

--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,12 @@
   "description": "A PSR-3 compliant logger with adjustable verbosity.",
   "type": "library",
   "require": {
-    "php": ">=7.1 <8.6",
+    "php": ">=7.2 <8.6",
     "psr/log": "^1.0.1 || ^2.0 || ^3.0",
-    "tracy/tracy": "^2.6.0"
+    "tracy/tracy": "^2.9.8 || ^2.10.9 || ^2.11.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7 || ^8 || ^9 || ^10 || ^11 || ^12"
+    "phpunit/phpunit": "^8.5.52 || ^9 || ^10 || ^11 || ^12"
   },
   "license": "MIT",
   "authors": [

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
     "tracy/tracy": "^2.9.8 || ^2.10.9 || ^2.11.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.5.52 || ^9 || ^10 || ^11 || ^12",
-    "webmozart/assert": "^1.11 || ^1.12 || ^2.1.6"
+    "phpunit/phpunit": "^8.5.52 || ^9 || ^10 || ^11 || ^12 || ^13",
+    "webmozart/assert": "^1.11 || ^2.1.6"
   },
   "license": "MIT",
   "authors": [

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -26,17 +26,13 @@ class Logger extends AbstractLogger implements LoggerInterface
     public const CONF_LOG_PROFILING_STEP = 'log_profiling_step';
     public const CONF_MAIL_FOR_ADMIN_ENABLED = 'mail_for_admin_enabled';
 
-    /** @var int */
-    // 0 = send message to PHP's system logger; recommended is however 3 (append to file)
+    /** @var int 0 = send message to PHP's system logger; recommended is however 3 (append to file) */
     private $errorLogMessageType = 0;
-    /** @var string */
-    // if errorLogMessageType equals 3, message is appended to this file destination (path and name)
+    /** @var string if errorLogMessageType equals 3, message is appended to this file destination (path and name) */
     private $loggingFile = '';
-    /** @var int */
-    // verbosity: log up to this level, default=5 (debug)
+    /** @var int verbosity: log up to this level, default=5 (debug) */
     private $loggingLevel = 5;
-    /** @var array<int,string> */
-    // rename or renumber, if needed
+    /** @var array<int,string> Note: rename or renumber, if needed */
     private $loggingLevelName = [
         0 => 'unknown',
         1 => 'fatal',
@@ -46,17 +42,13 @@ class Logger extends AbstractLogger implements LoggerInterface
         5 => 'debug',
         6 => 'speed',
     ];
-    /** @var int */
-    // the logging level to which page generation speed (error_number 6) is to be logged
+    /** @var int the logging level to which page generation speed (error_number 6) is to be logged */
     private $loggingLevelPageSpeed = 5;
-    /** @var bool */
-    // false => use loggingFile as destination; true => adds .Y-m.log suffix for monthly rotation
+    /** @var bool false => use loggingFile as destination; true => adds .Y-m.log suffix for monthly rotation */
     private $logMonthlyRotation = true;
-    /** @var bool|float */
-    // prefix message that took longer than profiling step (float seconds) by SLOWSTEP
+    /** @var bool|float prefix message that took longer than profiling step (float seconds) by SLOWSTEP */
     private $logProfilingStep = false;
-    /** @var bool|string */
-    // when string, treated as admin email for level 1 notifications
+    /** @var bool|string when string, treated as admin email for level <=1 notifications */
     private $mailForAdminEnabled = false;
 
     /** @var int */
@@ -98,7 +90,7 @@ class Logger extends AbstractLogger implements LoggerInterface
             # normalize to array<int,string>
             $normalized = [];
             foreach ($conf[self::CONF_LOGGING_LEVEL_NAME] as $k => $v) {
-                Assert::string($v, 'Each logging level name must be a string.');
+                Assert::string($v, 'Each logging level name MUST be a string.');
                 $normalized[(int) $k] = (string) $v;
             }
             $this->loggingLevelName = $normalized;

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -376,15 +376,6 @@ class Logger extends AbstractLogger implements LoggerInterface
                 $message = 'SLOWSTEP ' . $message; //110812, PROFILING
             }
 
-            // checks for the static code analysis
-            if (!is_array($this->loggingLevelName)) {
-                $this->loggingLevelName = [];
-            }
-            if (
-                !is_string($this->loggingLevelName[$level])
-            ) {
-                $this->loggingLevelName[$level] = 'non-string';
-            }
             $message_prefix = '[' . date('d-M-Y H:i:s') . '] [' . $this->loggingLevelName[$level]
                 . '] [' . $error_number . '] ['
                 . ((isset($_SERVER['SCRIPT_FILENAME']) && is_string($_SERVER['SCRIPT_FILENAME'])) //
@@ -408,9 +399,6 @@ class Logger extends AbstractLogger implements LoggerInterface
             } else {
                 $messageType = ($this->errorLogMessageType === 0)
                     ? $this->errorLogMessageType : 3;
-                if (!is_string($this->loggingFile)) {
-                    $this->loggingFile = './error_log'; // a forced default
-                }
                 $result = $this->logMonthlyRotation
                     ? error_log(
                         $message_prefix . $message . (($messageType != 0) ? PHP_EOL : ''),

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -360,7 +360,7 @@ class Logger extends AbstractLogger implements LoggerInterface
 
             // checks for the static code analysis
             if (!is_array($this->loggingLevelName)) {
-                $this->conf[self::CONF_LOGGING_LEVEL_NAME] = [];
+                $this->loggingLevelName = [];
             }
             if (
                 !is_string($this->loggingLevelName[$level])

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -26,12 +26,16 @@ class Logger extends AbstractLogger implements LoggerInterface
     public const CONF_MAIL_FOR_ADMIN_ENABLED = 'mail_for_admin_enabled';
 
     /** @var int */
+    // 0 = send message to PHP's system logger; recommended is however 3 (append to file)
     private $errorLogMessageType = 0;
     /** @var string */
+    // if errorLogMessageType equals 3, message is appended to this file destination (path and name)
     private $loggingFile = '';
     /** @var int */
+    // verbosity: log up to this level, default=5 (debug)
     private $loggingLevel = 5;
     /** @var array<int,string> */
+    // rename or renumber, if needed
     private $loggingLevelName = [
         0 => 'unknown',
         1 => 'fatal',
@@ -42,12 +46,16 @@ class Logger extends AbstractLogger implements LoggerInterface
         6 => 'speed',
     ];
     /** @var int */
+    // the logging level to which page generation speed (error_number 6) is to be logged
     private $loggingLevelPageSpeed = 5;
     /** @var bool */
+    // false => use loggingFile as destination; true => adds .Y-m.log suffix for monthly rotation
     private $logMonthlyRotation = true;
     /** @var bool|float */
+    // prefix message that took longer than profiling step (float seconds) by SLOWSTEP
     private $logProfilingStep = false;
     /** @var bool|string */
+    // when string, treated as admin email for level 1 notifications
     private $mailForAdminEnabled = false;
 
     /** @var int */
@@ -67,41 +75,34 @@ class Logger extends AbstractLogger implements LoggerInterface
     {
         $this->time = ($time === null) ? (new LoggerTime()) : $time;
 
-        // default values
-        $defaults = [
-            self::CONF_ERROR_LOG_MESSAGE_TYPE => 0,
-            self::CONF_LOGGING_FILE => '',
-            self::CONF_LOGGING_LEVEL => 5,
-            self::CONF_LOGGING_LEVEL_NAME => [
-                0 => 'unknown',
-                1 => 'fatal',
-                2 => 'error',
-                3 => 'warning',
-                4 => 'info',
-                5 => 'debug',
-                6 => 'speed',
-            ],
-            self::CONF_LOGGING_LEVEL_PAGE_SPEED => 5,
-            self::CONF_LOG_MONTHLY_ROTATION => true,
-            self::CONF_LOG_PROFILING_STEP => false,
-            self::CONF_MAIL_FOR_ADMIN_ENABLED => false,
-        ];
-
-        $conf = array_merge($defaults, $conf);
-
-        if (!is_int($conf[self::CONF_LOGGING_LEVEL])) {
-            throw new \Psr\Log\InvalidArgumentException('The logging_level MUST be an integer.');
+        // prefer explicit property defaults; only override when config key is provided
+        if (isset($conf[self::CONF_ERROR_LOG_MESSAGE_TYPE])) {
+            $this->errorLogMessageType = (int) $conf[self::CONF_ERROR_LOG_MESSAGE_TYPE];
         }
-
-        // assign to explicit properties with proper typing
-        $this->errorLogMessageType = (int) $conf[self::CONF_ERROR_LOG_MESSAGE_TYPE];
-        $this->loggingFile = (string) $conf[self::CONF_LOGGING_FILE];
-        $this->loggingLevel = (int) $conf[self::CONF_LOGGING_LEVEL];
-        $this->loggingLevelName = is_array($conf[self::CONF_LOGGING_LEVEL_NAME]) ? $conf[self::CONF_LOGGING_LEVEL_NAME] : $this->loggingLevelName;
-        $this->loggingLevelPageSpeed = (int) $conf[self::CONF_LOGGING_LEVEL_PAGE_SPEED];
-        $this->logMonthlyRotation = (bool) $conf[self::CONF_LOG_MONTHLY_ROTATION];
-        $this->logProfilingStep = $conf[self::CONF_LOG_PROFILING_STEP];
-        $this->mailForAdminEnabled = $conf[self::CONF_MAIL_FOR_ADMIN_ENABLED];
+        if (isset($conf[self::CONF_LOGGING_FILE])) {
+            $this->loggingFile = (string) $conf[self::CONF_LOGGING_FILE];
+        }
+        if (isset($conf[self::CONF_LOGGING_LEVEL])) {
+            if (!is_int($conf[self::CONF_LOGGING_LEVEL])) {
+                throw new \Psr\Log\InvalidArgumentException('The logging_level MUST be an integer.');
+            }
+            $this->loggingLevel = (int) $conf[self::CONF_LOGGING_LEVEL];
+        }
+        if (isset($conf[self::CONF_LOGGING_LEVEL_NAME]) && is_array($conf[self::CONF_LOGGING_LEVEL_NAME])) {
+            $this->loggingLevelName = $conf[self::CONF_LOGGING_LEVEL_NAME];
+        }
+        if (isset($conf[self::CONF_LOGGING_LEVEL_PAGE_SPEED])) {
+            $this->loggingLevelPageSpeed = (int) $conf[self::CONF_LOGGING_LEVEL_PAGE_SPEED];
+        }
+        if (isset($conf[self::CONF_LOG_MONTHLY_ROTATION])) {
+            $this->logMonthlyRotation = (bool) $conf[self::CONF_LOG_MONTHLY_ROTATION];
+        }
+        if (isset($conf[self::CONF_LOG_PROFILING_STEP])) {
+            $this->logProfilingStep = $conf[self::CONF_LOG_PROFILING_STEP];
+        }
+        if (isset($conf[self::CONF_MAIL_FOR_ADMIN_ENABLED])) {
+            $this->mailForAdminEnabled = $conf[self::CONF_MAIL_FOR_ADMIN_ENABLED];
+        }
 
         $this->overrideLoggingLevel = $this->loggingLevel;
     }

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -77,7 +77,11 @@ class Logger extends AbstractLogger implements LoggerInterface
 
         // prefer explicit property defaults; only override when config key is provided
         if (isset($conf[self::CONF_ERROR_LOG_MESSAGE_TYPE])) {
-            $this->errorLogMessageType = (int) $conf[self::CONF_ERROR_LOG_MESSAGE_TYPE];
+            $v = $conf[self::CONF_ERROR_LOG_MESSAGE_TYPE];
+            if (!is_int($v) && !is_numeric($v)) {
+                throw new \Psr\Log\InvalidArgumentException('The error_log_message_type MUST be an integer.');
+            }
+            $this->errorLogMessageType = (int) $v;
         }
         if (isset($conf[self::CONF_LOGGING_FILE])) {
             $this->loggingFile = (string) $conf[self::CONF_LOGGING_FILE];
@@ -98,10 +102,18 @@ class Logger extends AbstractLogger implements LoggerInterface
             $this->logMonthlyRotation = (bool) $conf[self::CONF_LOG_MONTHLY_ROTATION];
         }
         if (isset($conf[self::CONF_LOG_PROFILING_STEP])) {
-            $this->logProfilingStep = $conf[self::CONF_LOG_PROFILING_STEP];
+            $v = $conf[self::CONF_LOG_PROFILING_STEP];
+            if (!is_bool($v) && !is_float($v) && !is_int($v)) {
+                throw new \Psr\Log\InvalidArgumentException('The log_profiling_step MUST be bool or float.');
+            }
+            $this->logProfilingStep = $v;
         }
         if (isset($conf[self::CONF_MAIL_FOR_ADMIN_ENABLED])) {
-            $this->mailForAdminEnabled = $conf[self::CONF_MAIL_FOR_ADMIN_ENABLED];
+            $v = $conf[self::CONF_MAIL_FOR_ADMIN_ENABLED];
+            if (!is_bool($v) && !is_string($v)) {
+                throw new \Psr\Log\InvalidArgumentException('The mail_for_admin_enabled MUST be bool or string (email).');
+            }
+            $this->mailForAdminEnabled = $v;
         }
 
         $this->overrideLoggingLevel = $this->loggingLevel;

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -25,41 +25,39 @@ class Logger extends AbstractLogger implements LoggerInterface
     public const CONF_LOG_PROFILING_STEP = 'log_profiling_step';
     public const CONF_MAIL_FOR_ADMIN_ENABLED = 'mail_for_admin_enabled';
 
-    /** @var array<mixed> int,string,bool,array */
-    protected $conf = [];
+    /** @var int */
+    private $errorLogMessageType = 0;
+    /** @var string */
+    private $loggingFile = '';
+    /** @var int */
+    private $loggingLevel = 5;
+    /** @var array<int,string> */
+    private $loggingLevelName = [
+        0 => 'unknown',
+        1 => 'fatal',
+        2 => 'error',
+        3 => 'warning',
+        4 => 'info',
+        5 => 'debug',
+        6 => 'speed',
+    ];
+    /** @var int */
+    private $loggingLevelPageSpeed = 5;
+    /** @var bool */
+    private $logMonthlyRotation = true;
+    /** @var bool|float */
+    private $logProfilingStep = false;
+    /** @var bool|string */
+    private $mailForAdminEnabled = false;
+
     /** @var int */
     private $overrideLoggingLevel;
     /** @var float */
     private $runningTime = 0;
     /** @var LoggerTime */
     protected $time;
-    /** @var string*/
+    /** @var string */
     private $user = 'unidentified';
-
-    //    /** @var int */
-    //    private $errorLogMessageType = 0;
-    //    /** @var string */
-    //    private $loggingFile = '';
-    //    /** @var int */
-    //    private $loggingLevel = 5;
-    //    /** @var array */
-    //    private $loggingLevelName = [
-    //        0 => 'unknown',
-    //        1 => 'fatal',
-    //        'error',
-    //        'warning',
-    //        'info',
-    //        'debug',
-    //        'speed',
-    //    ];
-    //    /** @var int */
-    //    private $loggingLevelPageSpeed = 5;
-    //    /** @var bool */
-    //    private $logMonthlyRotation = true;
-    //    /** @var bool|float */
-    //    private $logProfilingStep = false;
-    //    /** @var bool|string */
-    //    private $mailForAdminEnabled = false;
 
     /**
      * @param array<mixed> $conf
@@ -68,57 +66,44 @@ class Logger extends AbstractLogger implements LoggerInterface
     public function __construct(array $conf = [], ?LoggerTime $time = null)
     {
         $this->time = ($time === null) ? (new LoggerTime()) : $time;
-        $this->conf = array_merge(
-            [ // default values
-                // 0 = send message to PHP's system logger;
-                // recommended is however 3, i.e. append to the file destination set in the field 'logging_file'
-                self::CONF_ERROR_LOG_MESSAGE_TYPE => 0,
-                // if error_log_message_type equals 3, the message is appended to this file destination (path and name)
-                self::CONF_LOGGING_FILE => '',
-                // verbosity: log up to the level set here, default=5 = debug
-                self::CONF_LOGGING_LEVEL => 5,
-                // rename or renumber, if needed
-                self::CONF_LOGGING_LEVEL_NAME => [
-                    0 => 'unknown',
-                    1 => 'fatal',
-                    'error',
-                    'warning',
-                    'info',
-                    'debug',
-                    'speed',
-                ],
-                // the logging level to which the page generation speed (i.e. error_number 6) is to be logged
-                self::CONF_LOGGING_LEVEL_PAGE_SPEED => 5,
-                // false => use logging_file with log extension as destination
-                // true => adds .Y-m.log to the logging file
-                self::CONF_LOG_MONTHLY_ROTATION => true,
-                // prefix message that took longer than profiling step (float) sec from the previous one by SLOWSTEP
-                self::CONF_LOG_PROFILING_STEP => false,
-                // A fatal error may be logged only.
-                // However, in production, set up an email address to enable error notifications.
-                self::CONF_MAIL_FOR_ADMIN_ENABLED => false,
+
+        // default values
+        $defaults = [
+            self::CONF_ERROR_LOG_MESSAGE_TYPE => 0,
+            self::CONF_LOGGING_FILE => '',
+            self::CONF_LOGGING_LEVEL => 5,
+            self::CONF_LOGGING_LEVEL_NAME => [
+                0 => 'unknown',
+                1 => 'fatal',
+                2 => 'error',
+                3 => 'warning',
+                4 => 'info',
+                5 => 'debug',
+                6 => 'speed',
             ],
-            $conf
-        );
-        if (!is_int($this->conf[self::CONF_LOGGING_LEVEL])) {
+            self::CONF_LOGGING_LEVEL_PAGE_SPEED => 5,
+            self::CONF_LOG_MONTHLY_ROTATION => true,
+            self::CONF_LOG_PROFILING_STEP => false,
+            self::CONF_MAIL_FOR_ADMIN_ENABLED => false,
+        ];
+
+        $conf = array_merge($defaults, $conf);
+
+        if (!is_int($conf[self::CONF_LOGGING_LEVEL])) {
             throw new \Psr\Log\InvalidArgumentException('The logging_level MUST be an integer.');
         }
-        $this->overrideLoggingLevel = $this->conf[self::CONF_LOGGING_LEVEL];
-        //@todo replace $this->conf by the class properties
 
-        //        $this->errorLogMessageType = $conf[self::CONF_ERROR_LOG_MESSAGE_TYPE] ?? $this->errorLogMessageType;
-        //        $this->loggingFile = $conf[self::CONF_LOGGING_FILE] ?? $this->loggingFile;
-        //        $this->loggingLevel = $conf[self::CONF_LOGGING_LEVEL] ?? $this->loggingLevel;
-        //        $this->loggingLevelName = $conf[self::CONF_LOGGING_LEVEL_NAME] ?? $this->loggingLevelName;
-        //    $this->loggingLevelPageSpeed = $conf[self::CONF_LOGGING_LEVEL_PAGE_SPEED] ?? $this->loggingLevelPageSpeed;
-        //        $this->logMonthlyRotation = $conf[self::CONF_LOG_MONTHLY_ROTATION] ?? $this->logMonthlyRotation;
-        //        $this->logProfilingStep = $conf[self::CONF_LOG_PROFILING_STEP] ?? $this->logProfilingStep;
-        //        $this->mailForAdminEnabled = $conf[self::CONF_MAIL_FOR_ADMIN_ENABLED] ?? $this->mailForAdminEnabled;
-        //
-        //        if (!is_int($this->loggingLevel)) {
-        //            throw new \Psr\Log\InvalidArgumentException('The logging_level MUST be an integer.');
-        //        }
-        //        $this->overrideLoggingLevel = $this->loggingLevel;
+        // assign to explicit properties with proper typing
+        $this->errorLogMessageType = (int) $conf[self::CONF_ERROR_LOG_MESSAGE_TYPE];
+        $this->loggingFile = (string) $conf[self::CONF_LOGGING_FILE];
+        $this->loggingLevel = (int) $conf[self::CONF_LOGGING_LEVEL];
+        $this->loggingLevelName = is_array($conf[self::CONF_LOGGING_LEVEL_NAME]) ? $conf[self::CONF_LOGGING_LEVEL_NAME] : $this->loggingLevelName;
+        $this->loggingLevelPageSpeed = (int) $conf[self::CONF_LOGGING_LEVEL_PAGE_SPEED];
+        $this->logMonthlyRotation = (bool) $conf[self::CONF_LOG_MONTHLY_ROTATION];
+        $this->logProfilingStep = $conf[self::CONF_LOG_PROFILING_STEP];
+        $this->mailForAdminEnabled = $conf[self::CONF_MAIL_FOR_ADMIN_ENABLED];
+
+        $this->overrideLoggingLevel = $this->loggingLevel;
     }
 
     /**
@@ -350,7 +335,7 @@ class Logger extends AbstractLogger implements LoggerInterface
             (
                 $level <= max(
                     [
-                        $this->conf[self::CONF_LOGGING_LEVEL],
+                        $this->loggingLevel,
                         $this->overrideLoggingLevel,
                     ]
                 )
@@ -359,29 +344,29 @@ class Logger extends AbstractLogger implements LoggerInterface
             // logging_level_page_speed has at least the severity of logging_level
             || (
                 ($error_number === 6)
-                && ($this->conf[self::CONF_LOGGING_LEVEL_PAGE_SPEED] <= $this->conf[self::CONF_LOGGING_LEVEL])
+                && ($this->loggingLevelPageSpeed <= $this->loggingLevel)
             )
         ) {
             $RUNNING_TIME_PREVIOUS = $this->runningTime;
             if (
                 (
                     (($this->runningTime = round($this->time->getmicrotime() - $this->time->getPageTimestamp(), 4))
-                    - $RUNNING_TIME_PREVIOUS) > $this->conf[self::CONF_LOG_PROFILING_STEP]
-                ) && $this->conf[self::CONF_LOG_PROFILING_STEP]
+                    - $RUNNING_TIME_PREVIOUS) > $this->logProfilingStep
+                ) && $this->logProfilingStep
             ) {
                 $message = 'SLOWSTEP ' . $message; //110812, PROFILING
             }
 
             // checks for the static code analysis
-            if (!is_array($this->conf[self::CONF_LOGGING_LEVEL_NAME])) {
+            if (!is_array($this->loggingLevelName)) {
                 $this->conf[self::CONF_LOGGING_LEVEL_NAME] = [];
             }
             if (
-                !is_string($this->conf[self::CONF_LOGGING_LEVEL_NAME][$level])
+                !is_string($this->loggingLevelName[$level])
             ) {
-                $this->conf[self::CONF_LOGGING_LEVEL_NAME][$level] = 'non-string';
+                $this->loggingLevelName[$level] = 'non-string';
             }
-            $message_prefix = '[' . date('d-M-Y H:i:s') . '] [' . $this->conf[self::CONF_LOGGING_LEVEL_NAME][$level]
+            $message_prefix = '[' . date('d-M-Y H:i:s') . '] [' . $this->loggingLevelName[$level]
                 . '] [' . $error_number . '] ['
                 . ((isset($_SERVER['SCRIPT_FILENAME']) && is_string($_SERVER['SCRIPT_FILENAME'])) //
                 ? $_SERVER['SCRIPT_FILENAME'] : 'no-script')
@@ -398,25 +383,25 @@ class Logger extends AbstractLogger implements LoggerInterface
                 . '] ';
             $result = true; //it could eventually be reset to false after calling error_log()
             // $logging_file not set and it should be
-            if (($this->conf[self::CONF_ERROR_LOG_MESSAGE_TYPE] == 3) && !$this->conf[self::CONF_LOGGING_FILE]) {
+            if (($this->errorLogMessageType == 3) && !$this->loggingFile) {
                 // so write into the default destination
                 $result = error_log("{$message_prefix}(error: logging_file should be set!) {$message}");
             } else {
-                $messageType = ($this->conf[self::CONF_ERROR_LOG_MESSAGE_TYPE] === 0)
-                    ? $this->conf[self::CONF_ERROR_LOG_MESSAGE_TYPE] : 3;
-                if (!is_string($this->conf[self::CONF_LOGGING_FILE])) {
-                    $this->conf[self::CONF_LOGGING_FILE] = './error_log'; // a forced default
+                $messageType = ($this->errorLogMessageType === 0)
+                    ? $this->errorLogMessageType : 3;
+                if (!is_string($this->loggingFile)) {
+                    $this->loggingFile = './error_log'; // a forced default
                 }
-                $result = $this->conf[self::CONF_LOG_MONTHLY_ROTATION]
+                $result = $this->logMonthlyRotation
                     ? error_log(
                         $message_prefix . $message . (($messageType != 0) ? PHP_EOL : ''),
                         $messageType,
-                        "{$this->conf[self::CONF_LOGGING_FILE]}." . date('Y-m') . '.log'
+                        "{$this->loggingFile}." . date('Y-m') . '.log'
                     ) // writes into a monthly rotating file
                     : error_log(
                         $message_prefix . $message . PHP_EOL,
                         $messageType,
-                        "{$this->conf[self::CONF_LOGGING_FILE]}.log"
+                        "{$this->loggingFile}.log"
                     ); // writes into one file
             }
             if ($result === false) {
@@ -424,13 +409,13 @@ class Logger extends AbstractLogger implements LoggerInterface
             }
             // mailto admin. 'mail_for_admin_enabled' has to be an email
             if (
-                $level === 1 && $this->conf[self::CONF_MAIL_FOR_ADMIN_ENABLED] //
-                && is_string($this->conf[self::CONF_MAIL_FOR_ADMIN_ENABLED])
+                $level === 1 && $this->mailForAdminEnabled //
+                && is_string($this->mailForAdminEnabled)
             ) {
                 $result2 = error_log(
                     $message_prefix . $message . PHP_EOL,
                     1,
-                    $this->conf[self::CONF_MAIL_FOR_ADMIN_ENABLED]
+                    $this->mailForAdminEnabled
                 );
                 if ($result2 === false) {
                     throw new ErrorLogFailureException('error_log() mailing failed');

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -7,7 +7,7 @@ namespace Seablast\Logger;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
-use WebMozart\Assert\Assert;
+use Webmozart\Assert\Assert;
 
 /**
  * A [PSR-3](http://www.php-fig.org/psr/psr-3/) compliant logger with adjustable verbosity.

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -7,6 +7,7 @@ namespace Seablast\Logger;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use WebMozart\Assert\Assert;
 
 /**
  * A [PSR-3](http://www.php-fig.org/psr/psr-3/) compliant logger with adjustable verbosity.
@@ -96,6 +97,7 @@ class Logger extends AbstractLogger implements LoggerInterface
             $this->loggingLevelName = $conf[self::CONF_LOGGING_LEVEL_NAME];
         }
         if (isset($conf[self::CONF_LOGGING_LEVEL_PAGE_SPEED])) {
+            Assert::integerish($conf[self::CONF_LOGGING_LEVEL_PAGE_SPEED], 'The logging_level_page_speed MUST be an integer.');
             $this->loggingLevelPageSpeed = (int) $conf[self::CONF_LOGGING_LEVEL_PAGE_SPEED];
         }
         if (isset($conf[self::CONF_LOG_MONTHLY_ROTATION])) {

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -104,7 +104,10 @@ class Logger extends AbstractLogger implements LoggerInterface
             $this->loggingLevelName = $normalized;
         }
         if (isset($conf[self::CONF_LOGGING_LEVEL_PAGE_SPEED])) {
-            Assert::integerish($conf[self::CONF_LOGGING_LEVEL_PAGE_SPEED], 'The logging_level_page_speed MUST be an integer.');
+            Assert::integerish(
+                $conf[self::CONF_LOGGING_LEVEL_PAGE_SPEED],
+                'The logging_level_page_speed MUST be an integer.'
+            );
             $this->loggingLevelPageSpeed = (int) $conf[self::CONF_LOGGING_LEVEL_PAGE_SPEED];
         }
         if (isset($conf[self::CONF_LOG_MONTHLY_ROTATION])) {
@@ -120,7 +123,9 @@ class Logger extends AbstractLogger implements LoggerInterface
         if (isset($conf[self::CONF_MAIL_FOR_ADMIN_ENABLED])) {
             $v = $conf[self::CONF_MAIL_FOR_ADMIN_ENABLED];
             if (!is_bool($v) && !is_string($v)) {
-                throw new \Psr\Log\InvalidArgumentException('The mail_for_admin_enabled MUST be bool or string (email).');
+                throw new \Psr\Log\InvalidArgumentException(
+                    'The mail_for_admin_enabled MUST be bool or string (email).'
+                );
             }
             $this->mailForAdminEnabled = $v;
         }

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -85,6 +85,7 @@ class Logger extends AbstractLogger implements LoggerInterface
             $this->errorLogMessageType = (int) $v;
         }
         if (isset($conf[self::CONF_LOGGING_FILE])) {
+            Assert::string($conf[self::CONF_LOGGING_FILE], 'The logging_file MUST be a string.');
             $this->loggingFile = (string) $conf[self::CONF_LOGGING_FILE];
         }
         if (isset($conf[self::CONF_LOGGING_LEVEL])) {
@@ -94,7 +95,13 @@ class Logger extends AbstractLogger implements LoggerInterface
             $this->loggingLevel = (int) $conf[self::CONF_LOGGING_LEVEL];
         }
         if (isset($conf[self::CONF_LOGGING_LEVEL_NAME]) && is_array($conf[self::CONF_LOGGING_LEVEL_NAME])) {
-            $this->loggingLevelName = $conf[self::CONF_LOGGING_LEVEL_NAME];
+            # normalize to array<int,string>
+            $normalized = [];
+            foreach ($conf[self::CONF_LOGGING_LEVEL_NAME] as $k => $v) {
+                Assert::string($v, 'Each logging level name must be a string.');
+                $normalized[(int) $k] = (string) $v;
+            }
+            $this->loggingLevelName = $normalized;
         }
         if (isset($conf[self::CONF_LOGGING_LEVEL_PAGE_SPEED])) {
             Assert::integerish($conf[self::CONF_LOGGING_LEVEL_PAGE_SPEED], 'The logging_level_page_speed MUST be an integer.');

--- a/test.php
+++ b/test.php
@@ -18,7 +18,7 @@ $conf = [
 ];
 $logger = new Logger($conf);
 
-echo "<h1>Compare to what appears in the {$conf[Logger::CONF_LOGGING_FILE]}" . date('Y-m') . ".log</h1>";
+echo "<h1>Compare to what appears in the error log: {$conf[Logger::CONF_LOGGING_FILE]}" . date('Y-m') . ".log</h1>";
 $severities = ['emergency', 'alert', 'critical', 'error', 'warning', 'notice', 'info', 'debug'];
 // Loop through levels 1 to 5
 for ($level = 1; $level <= 5; $level++) {


### PR DESCRIPTION
### Changed

- package limited to the tested PHP versions, i.e. "php": ">=7.2 <8.6"
- GitHub Actions version bump to super-linter v8.5.0
- Logger refactor: replaced legacy protected $conf array with explicit, typed class properties (errorLogMessageType, loggingFile, loggingLevel, loggingLevelName, loggingLevelPageSpeed, logMonthlyRotation, logProfilingStep, mailForAdminEnabled) to improve type safety and static analysis compatibility.
- Constructor now prefers property defaults and only overrides properties when config keys are present; config values are validated/narrowed before assignment to satisfy PHPStan and avoid unsafe casts.
- Introduced WebMozart Assert for concise runtime validations where appropriate.

### Added

- PHPStan-friendly type hints and PHPDoc improvements for Logger properties (e.g. array<int,string> for loggingLevelName).

### Security

- fix: remove support below PHP/7.2, because of CVE-2026-24765
