### PR TITLE
fix: fix security to prevent forged log entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 #disable temporary and log files and dirs
 *.log
 /.phpunit.result.cache
+/.composer-cache
 
 #disable composer-managed libraries
 /vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Keep the Composer PHP constraint exactly as `"php": ">=7.2 <8.6"` unless the use
 
 ## Change Rules
 
-- Never remove comments. You may update comments for clarity, translate them to English, or remove a TODO only when the TODO is actually solved.
+- Never remove comments. You may update comments for clarity, translate them to English, or remove a `TODO` only when the `TODO` is actually solved.
 - Update `CHANGELOG.md` in English for notable changes.
 - Keep docs and examples aligned with `src/Logger.php`, especially logging levels, file rotation, and PHP version support.
 - Check security implications when changing logging behavior. Treat log destination paths, email destinations, host lookups, and user-controlled log text carefully.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,28 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added` for new features
 
-- Added `AGENTS.md` with repository workflow notes for future coding agents.
-- Added PHPUnit coverage for `Logger` file output, verbosity filtering, unsupported PSR-3 levels, and non-numeric context values.
-
 ### `Changed` for changes in existing functionality
 
-- Clarified package and README descriptions around `error_log()`, speed-level behavior, PSR-3 context handling, and the supported PHP range.
 - Describe `FixedLoggerTime` as a deterministic helper for `LoggerTest.php`.
-- Documented why `Logger` constructor configuration is typed as `array<string,mixed>`.
 
 ### `Deprecated` for soon-to-be removed features
 
 ### `Removed` for now removed features
 
-- Removed the no-op `LoggerTimeTest::tearDown()` hook.
-
 ### `Fixed` for any bugfixes
 
 - Move `FixedLoggerTime` into its own test helper file to satisfy PHPCS class-per-file rules.
 - Fix PHPStan findings in logger tests after adding log-injection coverage.
-- Fixed PSR-3 context handling so non-numeric context values no longer get cast while resolving the optional log error number.Allowing for `$logger->info('Failed request', ['exception' => $e]);` extra data.
-- Fixed unsupported string log levels to throw `Psr\Log\InvalidArgumentException` instead of writing a secondary log entry.
-- Fixed logging level names to fall back to `unknown` for numeric levels without a configured name.
 
 ### `Security` in case of vulnerabilities
 
@@ -39,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Escape control characters in log-line fields to prevent forged log entries.
 - Promote `webmozart/assert` to runtime dependencies so production installs include the assertion class used by `Logger`.
 
-## [2.0.6] - 2026-05-24
+## [2.0.6] - 2026-06-19
 
 refactor: fix PSR-3 context handling
 
@@ -50,7 +40,7 @@ refactor: fix PSR-3 context handling
 
 ### Changed
 
-- Clarified package and README descriptions around `error_log()`, speed-level behavior, PSR-3 context handling, and the supported PHP range.
+- Clarified package and [README.md](README.md) descriptions around `error_log()`, speed-level behavior, PSR-3 context handling, and the supported PHP range.
 - Documented why `Logger` constructor configuration is typed as `array<string,mixed>`.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,25 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed` for changes in existing functionality
 
-- Describe `FixedLoggerTime` as a deterministic helper for `LoggerTest.php`.
-
 ### `Deprecated` for soon-to-be removed features
 
 ### `Removed` for now removed features
 
 ### `Fixed` for any bugfixes
 
-- Move `FixedLoggerTime` into its own test helper file to satisfy PHPCS class-per-file rules.
-- Fix PHPStan findings in logger tests after adding log-injection coverage.
-
 ### `Security` in case of vulnerabilities
 
-- Use a runtime-created log directory for the demo logger destination.
-- Warn that `logging_file` must stay trusted and outside the public web directory.
-- Escape control characters in log-line fields to prevent forged log entries.
-- Promote `webmozart/assert` to runtime dependencies so production installs include the assertion class used by `Logger`.
-
-## [2.0.6] - 2026-06-19
+## [2.0.6] - 2026-06-20
 
 refactor: fix PSR-3 context handling
 
@@ -42,6 +32,7 @@ refactor: fix PSR-3 context handling
 
 - Clarified package and [README.md](README.md) descriptions around `error_log()`, speed-level behavior, PSR-3 context handling, and the supported PHP range.
 - Documented why `Logger` constructor configuration is typed as `array<string,mixed>`.
+- Describe `FixedLoggerTime` as a deterministic helper for `LoggerTest.php`.
 
 ### Removed
 
@@ -53,6 +44,15 @@ refactor: fix PSR-3 context handling
 - Fixed unsupported string log levels to throw `Psr\Log\InvalidArgumentException` instead of writing a secondary log entry.
 - Fixed logging level names to fall back to `unknown` for numeric levels without a configured name.
 - Fixed log message normalization so PHPStan can prove messages are strings before writing to `error_log()`.
+- Move `FixedLoggerTime` into its own test helper file to satisfy PHPCS class-per-file rules.
+- Fix PHPStan findings in logger tests after adding log-injection coverage.
+
+### Security
+
+- Use a runtime-created log directory for the demo logger destination.
+- Warn that `logging_file` must stay trusted and outside the public web directory.
+- Escape control characters in log-line fields to prevent forged log entries.
+- Promote `webmozart/assert` to runtime dependencies so production installs include the assertion class used by `Logger`.
 
 ## [2.0.5] - 2026-03-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed` for any bugfixes
 
+- Fix PHPStan findings in logger tests after adding log-injection coverage.
 - Fixed PSR-3 context handling so non-numeric context values no longer get cast while resolving the optional log error number.Allowing for `$logger->info('Failed request', ['exception' => $e]);` extra data.
 - Fixed unsupported string log levels to throw `Psr\Log\InvalidArgumentException` instead of writing a secondary log entry.
 - Fixed logging level names to fall back to `unknown` for numeric levels without a configured name.
 
 ### `Security` in case of vulnerabilities
 
+- Warn that `logging_file` must stay trusted and outside the public web directory.
 - Escape control characters in log-line fields to prevent forged log entries.
 - Promote `webmozart/assert` to runtime dependencies so production installs include the assertion class used by `Logger`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Changed` for changes in existing functionality
 
 - Clarified package and README descriptions around `error_log()`, speed-level behavior, PSR-3 context handling, and the supported PHP range.
+- Describe `FixedLoggerTime` as a deterministic helper for `LoggerTest.php`.
 - Documented why `Logger` constructor configuration is typed as `array<string,mixed>`.
 
 ### `Deprecated` for soon-to-be removed features
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed` for any bugfixes
 
+- Move `FixedLoggerTime` into its own test helper file to satisfy PHPCS class-per-file rules.
 - Fix PHPStan findings in logger tests after adding log-injection coverage.
 - Fixed PSR-3 context handling so non-numeric context values no longer get cast while resolving the optional log error number.Allowing for `$logger->info('Failed request', ['exception' => $e]);` extra data.
 - Fixed unsupported string log levels to throw `Psr\Log\InvalidArgumentException` instead of writing a secondary log entry.
@@ -32,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
+- Use a runtime-created log directory for the demo logger destination.
 - Warn that `logging_file` must stay trusted and outside the public web directory.
 - Escape control characters in log-line fields to prevent forged log entries.
 - Promote `webmozart/assert` to runtime dependencies so production installs include the assertion class used by `Logger`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added` for new features
 
+- Added `AGENTS.md` with repository workflow notes for future coding agents.
+- Added PHPUnit coverage for `Logger` file output, verbosity filtering, unsupported PSR-3 levels, and non-numeric context values.
+
 ### `Changed` for changes in existing functionality
+
+- Clarified package and README descriptions around `error_log()`, speed-level behavior, PSR-3 context handling, and the supported PHP range.
+- Documented why `Logger` constructor configuration is typed as `array<string,mixed>`.
 
 ### `Deprecated` for soon-to-be removed features
 
 ### `Removed` for now removed features
 
+- Removed the no-op `LoggerTimeTest::tearDown()` hook.
+
 ### `Fixed` for any bugfixes
 
+- Fixed PSR-3 context handling so non-numeric context values no longer get cast while resolving the optional log error number.Allowing for `$logger->info('Failed request', ['exception' => $e]);` extra data.
+- Fixed unsupported string log levels to throw `Psr\Log\InvalidArgumentException` instead of writing a secondary log entry.
+- Fixed logging level names to fall back to `unknown` for numeric levels without a configured name.
+
 ### `Security` in case of vulnerabilities
+
+- Escape control characters in log-line fields to prevent forged log entries.
+- Promote `webmozart/assert` to runtime dependencies so production installs include the assertion class used by `Logger`.
 
 ## [2.0.6] - 2026-05-24
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $logger = new Logger($conf);
 
 See [test.php](test.php) for usage.
 
-Security note: `logging_file` is a filesystem destination. Keep it under application control, do not fill it directly from user input, environment values, or request data without validation, and prefer a directory outside the public web root so logs cannot be downloaded by clients.
+Security note: `logging_file` is a filesystem destination. Keep it under application control, do not fill it directly from user input, environment values, or request data without validation, and prefer a directory outside the public web root so logs cannot be downloaded by clients. Log entries can include diagnostic data such as script paths and full request URIs, including query strings, so treat log files as sensitive data available only to authorized operators.
 
 When using `log()` directly, pass a standard PSR-3 string level such as `LogLevel::INFO` or a numeric level from `CONF_LOGGING_LEVEL_NAME`. The optional context key `error_number`, or the first numeric context value, selects the category written in the log prefix; other PSR-3 context values are left untouched and are not interpolated into the message.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ $conf = array(
     // THESE ARE THE DEFAULT SETTINGS
     // 0 = send message to PHP's system logger; 3 appends to the file destination set in 'logging_file'
     Logger::CONF_ERROR_LOG_MESSAGE_TYPE => 0,
-    // if error_log_message_type equals 3, the message is appended to this file destination (path and name)
+    // if error_log_message_type equals 3, the message is appended to this file destination (path and name);
+    // keep this path trusted and outside the public web directory
     Logger::CONF_LOGGING_FILE => '',
     // verbosity: log up to the level set here, default=5 = debug; level 6 = speed is ignored by default
     Logger::CONF_LOGGING_LEVEL => 5,
@@ -35,6 +36,8 @@ $logger = new Logger($conf);
 ```
 
 See [test.php](test.php) for usage.
+
+Security note: `logging_file` is a filesystem destination. Keep it under application control, do not fill it directly from user input, environment values, or request data without validation, and prefer a directory outside the public web root so logs cannot be downloaded by clients.
 
 When using `log()` directly, pass a standard PSR-3 string level such as `LogLevel::INFO` or a numeric level from `CONF_LOGGING_LEVEL_NAME`. The optional context key `error_number`, or the first numeric context value, selects the category written in the log prefix; other PSR-3 context values are left untouched and are not interpolated into the message.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # seablast-logger
 
+[![Total Downloads](https://img.shields.io/packagist/dt/seablast/logger.svg)](https://packagist.org/packages/seablast/logger)
+[![Latest Stable Version](https://img.shields.io/packagist/v/seablast/logger.svg)](https://packagist.org/packages/seablast/logger)
+[![Polish the code](https://github.com/WorkOfStan/seablast-logger/actions/workflows/polish-the-code.yml/badge.svg)](https://github.com/WorkOfStan/seablast-logger/actions/workflows/polish-the-code.yml)
+
 A [PSR-3](http://www.php-fig.org/psr/psr-3/) compliant logger with adjustable verbosity.
 
 The logging level verbosity can be tailored to suit different environments.

--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,11 @@
   "require": {
     "php": ">=7.2 <8.6",
     "psr/log": "^1.0.1 || ^2.0 || ^3.0",
-    "tracy/tracy": "^2.9.8 || ^2.10.9 || ^2.11.0"
+    "tracy/tracy": "^2.9.8 || ^2.10.9 || ^2.11.0",
+    "webmozart/assert": "^1.11 || ^2.1.6"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.5.52 || ^9 || ^10 || ^11 || ^12 || ^13",
-    "webmozart/assert": "^1.11 || ^2.1.6"
+    "phpunit/phpunit": "^8.5.52 || ^9 || ^10 || ^11 || ^12 || ^13"
   },
   "license": "MIT",
   "authors": [

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -386,7 +386,7 @@ class Logger extends AbstractLogger implements LoggerInterface
                 . '] ['
                 . $user . '@'
                 . $host
-                . '] [' . $this->runningTime . '] ['                
+                . '] [' . $this->runningTime . '] ['
                 . $requestUri
                 . '] ';
             $result = true; //it could eventually be reset to false after calling error_log()

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -370,9 +370,12 @@ class Logger extends AbstractLogger implements LoggerInterface
             $scriptFilename = (isset($_SERVER['SCRIPT_FILENAME']) && is_string($_SERVER['SCRIPT_FILENAME'])) //
                 ? $this->sanitizeLogText($_SERVER['SCRIPT_FILENAME']) : 'no-script';
             $user = $this->sanitizeLogText($this->user);
+            // PHPUnit test (CLI) does not set REMOTE_ADDR
+            // TODO what if gethostbyaddr can't resolve the IP? And wouldn't be faster to just log IP?
             $resolvedHost = (isset($_SERVER['REMOTE_ADDR']) && is_string($_SERVER['REMOTE_ADDR'])) //
                 ? gethostbyaddr($_SERVER['REMOTE_ADDR']) : '-';
             $host = is_string($resolvedHost) ? $this->sanitizeLogText($resolvedHost) : '-';
+            // PHPUnit test (CLI) does not set REQUEST_URI
             $requestUri = (isset($_SERVER['REQUEST_URI']) && is_string($_SERVER['REQUEST_URI'])) //
                 ? $this->sanitizeLogText($_SERVER['REQUEST_URI']) : '-';
 
@@ -382,11 +385,8 @@ class Logger extends AbstractLogger implements LoggerInterface
                 . $scriptFilename
                 . '] ['
                 . $user . '@'
-                // PHPUnit test (CLI) does not set REMOTE_ADDR
-                // TODO what if gethostbyaddr can't resolve the IP? And wouldn't be faster to just log IP?
                 . $host
-                . '] [' . $this->runningTime . '] ['
-                // PHPUnit test (CLI) does not set REQUEST_URI
+                . '] [' . $this->runningTime . '] ['                
                 . $requestUri
                 . '] ';
             $result = true; //it could eventually be reset to false after calling error_log()

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -365,21 +365,29 @@ class Logger extends AbstractLogger implements LoggerInterface
             ) {
                 $message = 'SLOWSTEP ' . $message; //110812, PROFILING
             }
+            $message = $this->sanitizeLogText($message);
 
-            $message_prefix = '[' . date('d-M-Y H:i:s') . '] [' . $this->getLoggingLevelName($level)
+            $scriptFilename = (isset($_SERVER['SCRIPT_FILENAME']) && is_string($_SERVER['SCRIPT_FILENAME'])) //
+                ? $this->sanitizeLogText($_SERVER['SCRIPT_FILENAME']) : 'no-script';
+            $user = $this->sanitizeLogText($this->user);
+            $resolvedHost = (isset($_SERVER['REMOTE_ADDR']) && is_string($_SERVER['REMOTE_ADDR'])) //
+                ? gethostbyaddr($_SERVER['REMOTE_ADDR']) : '-';
+            $host = is_string($resolvedHost) ? $this->sanitizeLogText($resolvedHost) : '-';
+            $requestUri = (isset($_SERVER['REQUEST_URI']) && is_string($_SERVER['REQUEST_URI'])) //
+                ? $this->sanitizeLogText($_SERVER['REQUEST_URI']) : '-';
+
+            $message_prefix = '[' . date('d-M-Y H:i:s') . '] ['
+                . $this->sanitizeLogText($this->getLoggingLevelName($level))
                 . '] [' . $error_number . '] ['
-                . ((isset($_SERVER['SCRIPT_FILENAME']) && is_string($_SERVER['SCRIPT_FILENAME'])) //
-                ? $_SERVER['SCRIPT_FILENAME'] : 'no-script')
+                . $scriptFilename
                 . '] ['
-                . $this->user . '@'
+                . $user . '@'
                 // PHPUnit test (CLI) does not set REMOTE_ADDR
                 // TODO what if gethostbyaddr can't resolve the IP? And wouldn't be faster to just log IP?
-                . ((isset($_SERVER['REMOTE_ADDR']) && is_string($_SERVER['REMOTE_ADDR'])) //
-                ? gethostbyaddr($_SERVER['REMOTE_ADDR']) : '-')
+                . $host
                 . '] [' . $this->runningTime . '] ['
                 // PHPUnit test (CLI) does not set REQUEST_URI
-                . ((isset($_SERVER['REQUEST_URI']) && is_string($_SERVER['REQUEST_URI'])) //
-                ? $_SERVER['REQUEST_URI'] : '-')
+                . $requestUri
                 . '] ';
             $result = true; //it could eventually be reset to false after calling error_log()
             // $logging_file not set and it should be
@@ -459,6 +467,32 @@ class Logger extends AbstractLogger implements LoggerInterface
         }
 
         throw new \Psr\Log\InvalidArgumentException('The log message MUST be a string or stringable object.');
+    }
+
+    /**
+     * @return string
+     */
+    private function sanitizeLogText(string $value): string
+    {
+        $sanitized = preg_replace_callback(
+            '/[\x00-\x1F\x7F]/',
+            /** @param array<int,string> $matches */
+            static function (array $matches): string {
+                switch ($matches[0]) {
+                    case "\r":
+                        return '\\r';
+                    case "\n":
+                        return '\\n';
+                    case "\t":
+                        return '\\t';
+                }
+
+                return sprintf('\\x%02X', ord($matches[0]));
+            },
+            $value
+        );
+
+        return ($sanitized === null) ? $value : $sanitized;
     }
 
     /**

--- a/test.php
+++ b/test.php
@@ -6,10 +6,19 @@ use Seablast\Logger\Logger;
 
 require 'vendor/autoload.php';
 
+$logDir = __DIR__ . '/log';
+if (!is_dir($logDir) && !mkdir($logDir, 0750, true) && !is_dir($logDir)) {
+    throw new RuntimeException(sprintf('Unable to create log directory "%s".', $logDir));
+}
+if (!is_writable($logDir)) {
+    throw new RuntimeException(sprintf('Log directory "%s" is not writable.', $logDir));
+}
+$logFile = $logDir . '/error_log';
+
 // Initialize the logger
 $conf = [
     Logger::CONF_ERROR_LOG_MESSAGE_TYPE => 3,
-    Logger::CONF_LOGGING_FILE => './error_log', // extension .log will be added automatically
+    Logger::CONF_LOGGING_FILE => $logFile, // extension .log will be added automatically
     Logger::CONF_LOGGING_LEVEL => 0, // start with logging almost nothing for purpose of test looping
     Logger::CONF_LOGGING_LEVEL_PAGE_SPEED => 5,
     Logger::CONF_LOG_MONTHLY_ROTATION => true,

--- a/test.php
+++ b/test.php
@@ -22,7 +22,7 @@ $conf = [
     Logger::CONF_LOGGING_LEVEL => 0, // start with logging almost nothing for purpose of test looping
     Logger::CONF_LOGGING_LEVEL_PAGE_SPEED => 5,
     Logger::CONF_LOG_MONTHLY_ROTATION => true,
-    Logger::CONF_LOG_PROFILING_STEP => 0.00048,
+    Logger::CONF_LOG_PROFILING_STEP => 0.00048, // very short to actually log all lines as SLOWSTEP
     Logger::CONF_MAIL_FOR_ADMIN_ENABLED => false,
 ];
 $logger = new Logger($conf);

--- a/tests/FixedLoggerTime.php
+++ b/tests/FixedLoggerTime.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seablast\Logger\Tests;
+
+use Seablast\Logger\LoggerTime;
+
+/**
+ * Helps LoggerTest.php assert log output with deterministic timestamps.
+ */
+class FixedLoggerTime extends LoggerTime
+{
+    /**
+     * @return float
+     */
+    public function getmicrotime(): float
+    {
+        return 100.1234;
+    }
+
+    /**
+     * @return float
+     */
+    public function getPageTimestamp(): float
+    {
+        return 100.0;
+    }
+}

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -110,6 +110,53 @@ class LoggerTest extends TestCase
     /**
      * @return void
      */
+    public function testControlCharactersAreEscapedInLogLineFields(): void
+    {
+        $baseFile = $this->tmpDir . DIRECTORY_SEPARATOR . 'logger';
+        $_SERVER['SCRIPT_FILENAME'] = "script\r\nforged.php";
+        $_SERVER['REQUEST_URI'] = "/safe\turi\x1Fnext\nfake";
+        $logger = new Logger(
+            [
+                Logger::CONF_ERROR_LOG_MESSAGE_TYPE => 3,
+                Logger::CONF_LOGGING_FILE => $baseFile,
+                Logger::CONF_LOGGING_LEVEL => 4,
+                Logger::CONF_LOGGING_LEVEL_NAME => [
+                    0 => 'unknown',
+                    1 => 'fatal',
+                    2 => 'error',
+                    3 => 'warning',
+                    4 => "info\nforged",
+                    5 => 'debug',
+                    6 => 'speed',
+                ],
+                Logger::CONF_LOG_MONTHLY_ROTATION => false,
+            ],
+            new FixedLoggerTime()
+        );
+        $logger->setUser("user\rforged");
+
+        $logger->info("Message\nforged\ragain\twith\x1Funit");
+
+        $contents = file_get_contents($baseFile . '.log');
+        self::assertIsString($contents);
+        self::assertStringContainsString(
+            '] [info\\nforged] [0] [script\\r\\nforged.php] [user\\rforged@-] [0.1234] '
+            . '[/safe\\turi\\x1Fnext\\nfake] Message\\nforged\\ragain\\twith\\x1Funit',
+            $contents
+        );
+        self::assertSame(1, substr_count($contents, PHP_EOL));
+
+        $lineWithoutEnding = substr($contents, 0, -strlen(PHP_EOL));
+        self::assertIsString($lineWithoutEnding);
+        self::assertStringNotContainsString("\r", $lineWithoutEnding);
+        self::assertStringNotContainsString("\n", $lineWithoutEnding);
+        self::assertStringNotContainsString("\t", $lineWithoutEnding);
+        self::assertStringNotContainsString("\x1F", $lineWithoutEnding);
+    }
+
+    /**
+     * @return void
+     */
     public function testUnsupportedPsrLevelThrows(): void
     {
         $baseFile = $this->tmpDir . DIRECTORY_SEPARATOR . 'logger';

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -7,7 +7,6 @@ namespace Seablast\Logger\Tests;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\InvalidArgumentException;
 use Seablast\Logger\Logger;
-use Seablast\Logger\LoggerTime;
 
 class LoggerTest extends TestCase
 {
@@ -218,24 +217,5 @@ class LoggerTest extends TestCase
             }
             usleep(10000);
         }
-    }
-}
-
-class FixedLoggerTime extends LoggerTime
-{
-    /**
-     * @return float
-     */
-    public function getmicrotime(): float
-    {
-        return 100.1234;
-    }
-
-    /**
-     * @return float
-     */
-    public function getPageTimestamp(): float
-    {
-        return 100.0;
     }
 }

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -14,7 +14,7 @@ class LoggerTest extends TestCase
     /** @var string */
     private $tmpDir;
 
-    /** @var array<string,mixed> */
+    /** @var array<mixed> */
     private $serverBackup;
 
     /**
@@ -147,7 +147,6 @@ class LoggerTest extends TestCase
         self::assertSame(1, substr_count($contents, PHP_EOL));
 
         $lineWithoutEnding = substr($contents, 0, -strlen(PHP_EOL));
-        self::assertIsString($lineWithoutEnding);
         self::assertStringNotContainsString("\r", $lineWithoutEnding);
         self::assertStringNotContainsString("\n", $lineWithoutEnding);
         self::assertStringNotContainsString("\t", $lineWithoutEnding);


### PR DESCRIPTION
### Changed

- Describe `FixedLoggerTime` as a deterministic helper for `LoggerTest.php`.

### Fixed

- Move `FixedLoggerTime` into its own test helper file to satisfy PHPCS class-per-file rules.

### Security

- Use a runtime-created log directory for the demo logger destination.
- Warn that `logging_file` must stay trusted and outside the public web directory.
- Escape control characters in log-line fields to prevent forged log entries.
- Promote `webmozart/assert` to runtime dependencies so production installs include the assertion class used by `Logger`.